### PR TITLE
ENH: add aerotech motors to example IOC, add split and delay IOC + attocube support

### DIFF
--- a/simioc/db/motor.py
+++ b/simioc/db/motor.py
@@ -194,6 +194,14 @@ class XpsMotor(Motor):
 
 
 class AerotechMotor(Motor):
+    """
+    Aerotech motor record + additional records.
+
+    Pairs with :class:`hxrsnd.aerotech.AeroBase`.
+
+    May not be entirely accurate with respect to record types.
+    """
+
     axis_status = pvproperty(
         name=":AXIS_STATUS",
         read_only=True,
@@ -222,3 +230,59 @@ class AerotechMotor(Motor):
         read_only=False,
         value=0,
     )
+
+
+class AttocubeMotor(PVGroup):
+    """
+    Not a motor record. Pairs with :class:`hxrsnd.attocube.EccBase`.
+
+    May not be entirely accurate with respect to record types.
+    """
+    # position
+    user_readback = pvproperty(value=0.0, read_only=True, name=":POSITION")
+    user_setpoint = pvproperty(value=0.0, name=":CMD:TARGET", record='ai')
+
+    # limits
+    # upper_ctrl_limit = pvproperty(name=':CMD:TARGET.HOPR')
+    # lower_ctrl_limit = pvproperty(name=':CMD:TARGET.LOPR')
+
+    # configuration
+    motor_egu = pvproperty(value='mm', read_only=True, name=":UNIT")
+    motor_amplitude = pvproperty(value=0.0, name=":CMD:AMPL")
+    motor_dc = pvproperty(value=0.0, name=":CMD:DC")
+    motor_frequency = pvproperty(value=0.0, name=":CMD:FREQ")
+
+    # motor status
+    motor_connected = pvproperty(value=True, read_only=True,
+                                 name=":ST_CONNECT")
+    motor_enabled = pvproperty(value=True, read_only=True, name=":ST_ENABLED")
+    motor_referenced = pvproperty(value=True, read_only=True,
+                                  name=":ST_REFVAL")
+    motor_error = pvproperty(value=False, read_only=True, name=":ST_ERROR")
+    motor_is_moving = pvproperty(value=False, read_only=True,
+                                 name=":RD_MOVING")
+    motor_done_move = pvproperty(value=False, read_only=True,
+                                 name=":RD_INRANGE")
+    high_limit_switch = pvproperty(value=False, name=":ST_EOT_FWD")
+    low_limit_switch = pvproperty(value=False, name=":ST_EOT_BWD")
+    motor_reference_position = pvproperty(value=0.0, read_only=True,
+                                          name=":REF_POSITION")
+
+    # commands
+    motor_stop = pvproperty(value=0, name=":CMD:STOP")
+    motor_reset = pvproperty(value=0, name=":CMD:RESET.PROC")
+    motor_enable = pvproperty(value=True, name=":CMD:ENABLE")
+
+    @user_setpoint.startup
+    async def user_setpoint(self, instance, async_lib):
+        """
+        Startup hook for user_setpoint.
+        """
+        await self.user_setpoint.field_inst.low_operating_range.write(
+            value=-10)
+        await self.user_setpoint.field_inst.high_operating_range.write(
+            value=10)
+
+    @user_setpoint.putter
+    async def user_setpoint(self, instance, value):
+        await self.user_readback.write(value=value)

--- a/simioc/db/motor.py
+++ b/simioc/db/motor.py
@@ -191,3 +191,34 @@ class XpsMotorFields(MotorFields):
 
 class XpsMotor(Motor):
     motor = pvproperty(value=0.0, name='', record='xps8p', precision=3)
+
+
+class AerotechMotor(Motor):
+    axis_status = pvproperty(
+        name=":AXIS_STATUS",
+        read_only=True,
+        value=0,
+    )
+
+    axis_fault = pvproperty(
+        name=":AXIS_FAULT",
+        read_only=True,
+        value=0,
+    )
+    clear_error = pvproperty(
+        name=":CLEAR",
+        read_only=False,
+        value=0,
+        record='bo',
+    )
+    config = pvproperty(
+        name=":CONFIG",
+        read_only=False,
+        value=0,
+    )
+    zero_all_proc = pvproperty(
+        name=":ZERO_P",
+        record='bo',
+        read_only=False,
+        value=0,
+    )

--- a/simioc/ioc/motor.py
+++ b/simioc/ioc/motor.py
@@ -1,6 +1,6 @@
 from caproto.server import PVGroup, SubGroup
 
-from ..db.motor import Motor, XpsMotor
+from ..db.motor import AerotechMotor, Motor, XpsMotor
 from .utils import main
 
 
@@ -24,6 +24,12 @@ class MotorIOC(PVGroup):
                           prefix='xps:mtr2')
     xps_motor3 = SubGroup(XpsMotor, velocity=3., precision=2,
                           prefix='xps:mtr3')
+    aero_motor1 = SubGroup(AerotechMotor, velocity=3., precision=2,
+                           prefix='aero:mtr1')
+    aero_motor2 = SubGroup(AerotechMotor, velocity=3., precision=2,
+                           prefix='aero:mtr2')
+    aero_motor3 = SubGroup(AerotechMotor, velocity=3., precision=2,
+                           prefix='aero:mtr3')
 
 
 if __name__ == '__main__':

--- a/simioc/ioc/split_and_delay.py
+++ b/simioc/ioc/split_and_delay.py
@@ -1,6 +1,6 @@
-from caproto.server import PVGroup, SubGroup
+from caproto.server import PVGroup, SubGroup, pvproperty
 
-from ..db.motor import AerotechMotor
+from ..db.motor import AerotechMotor, AttocubeMotor
 from .utils import main
 
 
@@ -168,6 +168,28 @@ class SplitAndDelayIOC(PVGroup):
         precision=default_prec,
         prefix=':DIA:DCO:X'
     )
+
+    t1_y1 = SubGroup(AttocubeMotor, prefix=':T1:Y1')
+    t1_y2 = SubGroup(AttocubeMotor, prefix=':T1:Y2')
+    t1_chi1 = SubGroup(AttocubeMotor, prefix=':T1:CHI1')
+    t1_chi2 = SubGroup(AttocubeMotor, prefix=':T1:CHI2')
+    t1_dh = SubGroup(AttocubeMotor, prefix=':T1:DH')
+    t4_y1 = SubGroup(AttocubeMotor, prefix=':T4:Y1')
+    t4_y2 = SubGroup(AttocubeMotor, prefix=':T4:Y2')
+    t4_chi1 = SubGroup(AttocubeMotor, prefix=':T4:CHI1')
+    t4_chi2 = SubGroup(AttocubeMotor, prefix=':T4:CHI2')
+    t4_dh = SubGroup(AttocubeMotor, prefix=':T4:DH')
+
+    n2_t1_gps = pvproperty(name=':N2:T1:GPS', value=1.0)
+    n2_t1_vgp = pvproperty(name=':N2:T1:VGP', value=1.0)
+    n2_t4_gps = pvproperty(name=':N2:T4:GPS', value=1.0)
+    n2_t4_vgp = pvproperty(name=':N2:T4:VGP', value=1.0)
+    t1_n2_t1_gps = pvproperty(name=':T1:N2:T1:GPS', value=1.0)
+    t4_n2_t4_gps = pvproperty(name=':T4:N2:T4:GPS', value=1.0)
+    vac_gps = pvproperty(name=':VAC:GPS', value=1.0)
+    vac_vgp = pvproperty(name=':VAC:VGP', value=1.0)
+
+    # TODO: standins for the areadetector components
 
 
 if __name__ == '__main__':

--- a/simioc/ioc/split_and_delay.py
+++ b/simioc/ioc/split_and_delay.py
@@ -1,0 +1,174 @@
+from caproto.server import PVGroup, SubGroup
+
+from ..db.motor import AerotechMotor
+from .utils import main
+
+
+class SplitAndDelayIOC(PVGroup):
+    """
+    A stand-in split and delay IOC, including:
+
+    * Aerotech stages
+    * The rest is TODO
+    """
+
+    default_velo = 3.
+    default_prec = 2
+
+    t1_tth = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T1:TTH'
+    )
+
+    t1_th1 = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T1:TH1'
+    )
+
+    t1_th2 = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T1:TH2'
+    )
+
+    t1_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T1:X'
+    )
+
+    t1_l = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T1:L'
+    )
+
+    t4_tth = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T4:TTH'
+    )
+
+    t4_th1 = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T4:TH1'
+    )
+
+    t4_th2 = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T4:TH2'
+    )
+
+    t4_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T4:X'
+    )
+
+    t4_l = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T4:L'
+    )
+
+    t2_th = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T2:TH'
+    )
+
+    t2_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T2:X'
+    )
+
+    t3_th = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T3:TH'
+    )
+
+    t3_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':T3:X'
+    )
+
+    dia_di_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':DIA:DI:X'
+    )
+
+    dia_dd_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':DIA:DD:X'
+    )
+
+    dia_dd_y = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':DIA:DD:Y'
+    )
+
+    dia_do_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':DIA:DO:X'
+    )
+
+    dia_dci_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':DIA:DCI:X'
+    )
+
+    dia_dcc_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':DIA:DCC:X'
+    )
+
+    dia_dcc_y = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':DIA:DCC:Y'
+    )
+
+    dia_dco_x = SubGroup(
+        AerotechMotor,
+        velocity=default_velo,
+        precision=default_prec,
+        prefix=':DIA:DCO:X'
+    )
+
+
+if __name__ == '__main__':
+    main(cls=SplitAndDelayIOC, default_prefix='PREFIX')


### PR DESCRIPTION
Not 100% accurate with respect to record types/values/enum strings, but PV names are at least correct