### PR TITLE
ENH: btps prototype simulation tools

### DIFF
--- a/simioc/db/motor.py
+++ b/simioc/db/motor.py
@@ -13,91 +13,136 @@ async def broadcast_precision_to_fields(record):
             await prop.write_metadata(precision=precision)
 
 
+async def motor_record_simulator(instance, async_lib, defaults=None,
+                                 tick_rate_hz=10.):
+    """
+    A simple motor record simulator.
+
+    Parameters
+    ----------
+    instance : pvproperty (ChannelDouble)
+        Ensure you set ``record='motor'`` in your pvproperty first.
+
+    async_lib : AsyncLibraryLayer
+
+    defaults : dict, optional
+        Defaults for velocity, precision, acceleration, limits, and resolution.
+
+    tick_rate_hz : float, optional
+        Update rate in Hz.
+    """
+    if defaults is None:
+        defaults = dict(
+            position=0.0,
+            velocity=0.1,
+            precision=3,
+            acceleration=1.0,
+            resolution=1e-6,
+            tick_rate_hz=10.,
+            user_limits=(0.0, 100.0),
+        )
+
+    fields = instance.field_inst  # type: MotorFields
+    have_new_position = False
+
+    async def value_write_hook(fields, value):
+        nonlocal have_new_position
+        # This happens when a user puts to `motor.VAL`
+        # print("New position requested!", value)
+        have_new_position = True
+
+    fields.value_write_hook = value_write_hook
+
+    await instance.write_metadata(precision=defaults["precision"])
+    await broadcast_precision_to_fields(instance)
+
+    await fields.user_readback_value.write(defaults["position"])
+    await instance.write(defaults["position"])
+    await fields.velocity.write(defaults["velocity"])
+    await fields.seconds_to_velocity.write(defaults["acceleration"])
+    await fields.motor_step_size.write(defaults["resolution"])
+    await fields.user_low_limit.write(defaults["user_limits"][0])
+    await fields.user_high_limit.write(defaults["user_limits"][1])
+
+    while True:
+        dwell = 1. / tick_rate_hz
+        target_pos = instance.value
+        diff = (target_pos - fields.user_readback_value.value)
+        # compute the total movement time based an velocity
+        total_time = abs(diff / fields.velocity.value)
+        # compute how many steps, should come up short as there will
+        # be a final write of the return value outside of this call
+        num_steps = int(total_time // dwell)
+        if abs(diff) < 1e-9 and not have_new_position:
+            if fields.stop.value != 0:
+                await fields.stop.write(0)
+            await async_lib.library.sleep(dwell)
+            continue
+
+        if fields.stop.value != 0:
+            await fields.stop.write(0)
+
+        await fields.done_moving_to_value.write(0)
+        await fields.motor_is_moving.write(1)
+
+        readback = fields.user_readback_value.value
+        step_size = diff / num_steps if num_steps > 0 else 0.0
+        resolution = max((fields.motor_step_size.value, 1e-10))
+
+        for _ in range(num_steps):
+            if fields.stop.value != 0:
+                await fields.stop.write(0)
+                await instance.write(readback)
+                break
+            if fields.stop_pause_move_go.value == "Stop":
+                await instance.write(readback)
+                break
+
+            readback += step_size
+            raw_readback = readback / resolution
+            await fields.user_readback_value.write(readback)
+            await fields.dial_readback_value.write(readback)
+            await fields.raw_readback_value.write(raw_readback)
+            await async_lib.library.sleep(dwell)
+        else:
+            # Only executed if we didn't break
+            await fields.user_readback_value.write(target_pos)
+
+        await fields.motor_is_moving.write(0)
+        await fields.done_moving_to_value.write(1)
+        have_new_position = False
+
+
 class Motor(PVGroup):
-    motor = pvproperty(value=0.0, name='', record='motor',
-                       precision=3)
+    motor = pvproperty(value=0.0, name='', record='motor', precision=3)
 
     def __init__(self, *args,
-                 velocity=0.1,
+                 position=0.0,
+                 velocity=1.0,
                  precision=3,
                  acceleration=1.0,
                  resolution=1e-6,
+                 user_limits=(0.0, 100.0),
                  tick_rate_hz=10.,
                  **kwargs):
         super().__init__(*args, **kwargs)
-        self._have_new_position = False
         self.tick_rate_hz = tick_rate_hz
         self.defaults = {
-            'velocity': velocity,
-            'precision': precision,
-            'acceleration': acceleration,
-            'resolution': resolution,
+            "position": position,
+            "velocity": velocity,
+            "precision": precision,
+            "acceleration": acceleration,
+            "resolution": resolution,
+            "user_limits": tuple(user_limits),
         }
-
-    @motor.putter
-    async def motor(self, instance, value):
-        self._have_new_position = True
-        return value
 
     @motor.startup
     async def motor(self, instance, async_lib):
-        self.async_lib = async_lib
-
-        await self.motor.write_metadata(precision=self.defaults['precision'])
-        await broadcast_precision_to_fields(self.motor)
-
-        fields = self.motor.field_inst  # type: MotorFields
-        await fields.velocity.write(self.defaults['velocity'])
-        await fields.seconds_to_velocity.write(self.defaults['acceleration'])
-        await fields.motor_step_size.write(self.defaults['resolution'])
-
-        while True:
-            dwell = 1. / self.tick_rate_hz
-            target_pos = self.motor.value
-            diff = (target_pos - fields.user_readback_value.value)
-            # compute the total movement time based an velocity
-            total_time = abs(diff / fields.velocity.value)
-            # compute how many steps, should come up short as there will
-            # be a final write of the return value outside of this call
-            num_steps = int(total_time // dwell)
-            if abs(diff) < 1e-9 and not self._have_new_position:
-                if fields.stop.value != 0:
-                    await fields.stop.write(0)
-                await async_lib.library.sleep(dwell)
-                continue
-
-            if fields.stop.value != 0:
-                await fields.stop.write(0)
-
-            await fields.done_moving_to_value.write(0)
-            await fields.motor_is_moving.write(1)
-
-            readback = fields.user_readback_value.value
-            step_size = diff / num_steps if num_steps > 0 else 0.0
-            resolution = max((fields.motor_step_size.value, 1e-10))
-
-            for _ in range(num_steps):
-                if fields.stop.value != 0:
-                    await fields.stop.write(0)
-                    await self.motor.write(readback)
-                    break
-                if fields.stop_pause_move_go.value == 'Stop':
-                    await self.motor.write(readback)
-                    break
-
-                readback += step_size
-                raw_readback = readback / resolution
-                await fields.user_readback_value.write(readback)
-                await fields.dial_readback_value.write(readback)
-                await fields.raw_readback_value.write(raw_readback)
-                await async_lib.library.sleep(dwell)
-            else:
-                # Only executed if we didn't break
-                await fields.user_readback_value.write(target_pos)
-
-            await fields.motor_is_moving.write(0)
-            await fields.done_moving_to_value.write(1)
-            self._have_new_position = False
+        # Start the simulator:
+        await motor_record_simulator(
+            self.motor, async_lib, self.defaults,
+            tick_rate_hz=self.tick_rate_hz,
+        )
 
 
 class BeckhoffAxisPLC(PVGroup):

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -1,0 +1,121 @@
+"""
+BTPS Simulator IOC for unit and integration tests.
+"""
+
+import random
+from caproto.server import PVGroup, SubGroup, pvproperty
+
+from ..db.motor import Motor
+from .utils import main
+
+
+class StatsPlugin(PVGroup):
+    """
+    Minimal AreaDetector stats plugin stand-in.
+
+    BTPS will check the array counter update rate and centroid values.
+    """
+    enable = pvproperty(value=1, name="SimEnable")
+    array_counter = pvproperty(value=0, name="ArrayCounter_RBV")
+    centroid_x = pvproperty(value=0.0, name="CentroidX_RBV")
+    centroid_y = pvproperty(value=0.0, name="CentroidY_RBV")
+
+    @enable.scan(period=1)
+    async def enable(self, instance, async_lib):
+        if self.enable.value == 0:
+            return
+       
+        await self.array_counter.write(value=self.array_counter.value + 1)
+        await self.centroid_x.write(value=random.random())
+        await self.centroid_y.write(value=random.random())
+
+
+class BtpsPrototypeSimulator(PVGroup):
+    """
+    A simulator for key BTPS PVs in the control system.
+
+    Listed PVs do not include the default "SIM:" prefix.
+
+    PVs
+    ---
+    Motor - Linear
+    LAS:BTS:MCS2:01:m1 (ioc-las-bts-mcs1)
+    LAS:BTS:MCS2:01:m4 (ioc-las-bts-mcs1)
+    LAS:BTS:MCS2:01:m7 (ioc-las-bts-mcs1)
+
+    Motor - Rotary
+    LAS:BTS:MCS2:01:m2 (ioc-las-bts-mcs1)
+    LAS:BTS:MCS2:01:m6 (ioc-las-bts-mcs1)
+    LAS:BTS:MCS2:01:m8 (ioc-las-bts-mcs1)
+
+    Motor - Goniometer
+    LAS:BTS:MCS2:01:m3 (ioc-las-bts-mcs1)
+    LAS:BTS:MCS2:01:m5 (ioc-las-bts-mcs1)
+    LAS:BTS:MCS2:01:m9 (ioc-las-bts-mcs1)
+
+    Source Gate Valve
+    LTLHN:LS1:VGC:01  (plc-las-bts)
+    LTLHN:LS5:VGC:01  (plc-las-bts)
+    LTLHN:LS8:VGC:01  (plc-las-bts)
+
+    LSS Shutter Request
+    LTLHN:LS1:LST:REQ (ioc-las-lhn-bhc-05)
+    LTLHN:LS5:LST:REQ (ioc-las-lhn-bhc-05)
+    LTLHN:LS8:LST:REQ (ioc-las-lhn-bhc-05)
+
+    LSS Shutter State - Open
+    LTLHN:LS1:LST:OPN (ioc-las-lhn-bhc-05)
+    LTLHN:LS5:LST:OPN (ioc-las-lhn-bhc-05)
+    LTLHN:LS8:LST:OPN (ioc-las-lhn-bhc-05)
+
+    LSS Shutter State - Closed
+    LTLHN:LS1:LST:CLS (ioc-las-lhn-bhc-05)
+    LTLHN:LS5:LST:CLS (ioc-las-lhn-bhc-05)
+    LTLHN:LS8:LST:CLS (ioc-las-lhn-bhc-05)
+
+    NF Camera
+    LAS:LHN:BAY1:CAM:01 (ioc-lhn-bay1-nf-01)
+    LAS:LHN:BAY3:CAM:01 (?, assumed)
+    LAS:LHN:BAY4:CAM:01 (ioc-lhn-bay4-nf-01)
+
+    FF Camera
+    LAS:LHN:BAY1:CAM:02 (ioc-lhn-bay1-ff-01)
+    LAS:LHN:BAY3:CAM:02 (?, assumed)
+    LAS:LHN:BAY4:CAM:02 (ioc-lhn-bay4-ff-01)
+
+    Destination Gate Valve PV
+    LTLHN:LD8:VGC:01 (ioc-las-bts) - TMO - IP1
+    LTLHN:LD10:VGC:01 (ioc-las-bts) - TMO - IP2
+    LTLHN:LD2:VGC:01 (ioc-las-bts) - TMO - IP3
+    LTLHN:LD6:VGC:01 (ioc-las-bts) - RIX - qRIXS
+    LTLH:LD4:VGC:01 (ioc-las-bts) - RIX - ChemRIXS
+    LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
+    LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
+    """
+
+    # Linear motors (ioc-las-bts-mcs1)
+    m1 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m1", user_limits=(0, 0))
+    m4 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m4", user_limits=(0, 2000))
+    m7 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m7", position=405.0, user_limits=(400, 1446.53))
+
+    # Rotary motors
+    m2 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m2", user_limits=(0, 0))
+    m6 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m6", user_limits=(-95, 95))
+    m8 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m8", user_limits=(-300, 300))
+
+    # Rotary motors
+    m3 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m3", user_limits=(0, 0))
+    m5 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m5", user_limits=(0, 0))
+    m9 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m9", user_limits=(0, 0))
+
+    nf_cam_bay1 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:01:Stats1:")
+    nf_cam_bay3 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:01:Stats1:")
+    nf_cam_bay4 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:01:Stats1:")
+
+    ff_cam_bay1 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:02:Stats1:")
+    ff_cam_bay3 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:02:Stats1:")
+    ff_cam_bay4 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:02:Stats1:")
+
+
+if __name__ == "__main__":
+    main(cls=BtpsPrototypeSimulator, default_prefix="SIM:")

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -39,58 +39,62 @@ class BtpsPrototypeSimulator(PVGroup):
     PVs
     ---
     Motor - Linear
-    LAS:BTS:MCS2:01:m1 (ioc-las-bts-mcs1)
-    LAS:BTS:MCS2:01:m4 (ioc-las-bts-mcs1)
-    LAS:BTS:MCS2:01:m7 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m1 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m4 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m7 (ioc-las-bts-mcs1)
 
     Motor - Rotary
-    LAS:BTS:MCS2:01:m2 (ioc-las-bts-mcs1)
-    LAS:BTS:MCS2:01:m6 (ioc-las-bts-mcs1)
-    LAS:BTS:MCS2:01:m8 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m2 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m6 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m8 (ioc-las-bts-mcs1)
 
     Motor - Goniometer
-    LAS:BTS:MCS2:01:m3 (ioc-las-bts-mcs1)
-    LAS:BTS:MCS2:01:m5 (ioc-las-bts-mcs1)
-    LAS:BTS:MCS2:01:m9 (ioc-las-bts-mcs1)
-
-    Source Gate Valve
-    LTLHN:LS1:VGC:01  (plc-las-bts)
-    LTLHN:LS5:VGC:01  (plc-las-bts)
-    LTLHN:LS8:VGC:01  (plc-las-bts)
-
-    LSS Shutter Request
-    LTLHN:LS1:LST:REQ (ioc-las-lhn-bhc-05)
-    LTLHN:LS5:LST:REQ (ioc-las-lhn-bhc-05)
-    LTLHN:LS8:LST:REQ (ioc-las-lhn-bhc-05)
-
-    LSS Shutter State - Open
-    LTLHN:LS1:LST:OPN (ioc-las-lhn-bhc-05)
-    LTLHN:LS5:LST:OPN (ioc-las-lhn-bhc-05)
-    LTLHN:LS8:LST:OPN (ioc-las-lhn-bhc-05)
-
-    LSS Shutter State - Closed
-    LTLHN:LS1:LST:CLS (ioc-las-lhn-bhc-05)
-    LTLHN:LS5:LST:CLS (ioc-las-lhn-bhc-05)
-    LTLHN:LS8:LST:CLS (ioc-las-lhn-bhc-05)
+        LAS:BTS:MCS2:01:m3 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m5 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m9 (ioc-las-bts-mcs1)
 
     NF Camera
-    LAS:LHN:BAY1:CAM:01 (ioc-lhn-bay1-nf-01)
-    LAS:LHN:BAY3:CAM:01 (?, assumed)
-    LAS:LHN:BAY4:CAM:01 (ioc-lhn-bay4-nf-01)
+        LAS:LHN:BAY1:CAM:01 (ioc-lhn-bay1-nf-01)
+        LAS:LHN:BAY3:CAM:01 (?, assumed)
+        LAS:LHN:BAY4:CAM:01 (ioc-lhn-bay4-nf-01)
 
     FF Camera
-    LAS:LHN:BAY1:CAM:02 (ioc-lhn-bay1-ff-01)
-    LAS:LHN:BAY3:CAM:02 (?, assumed)
-    LAS:LHN:BAY4:CAM:02 (ioc-lhn-bay4-ff-01)
+        LAS:LHN:BAY1:CAM:02 (ioc-lhn-bay1-ff-01)
+        LAS:LHN:BAY3:CAM:02 (?, assumed)
+        LAS:LHN:BAY4:CAM:02 (ioc-lhn-bay4-ff-01)
+
+    The following are sourced from plc-las-bts:
+
+    Source Gate Valve
+        LTLHN:LS1:VGC:01 (ioc-las-bts)
+        LTLHN:LS5:VGC:01 (ioc-las-bts)
+        LTLHN:LS8:VGC:01 (ioc-las-bts)
 
     Destination Gate Valve PV
-    LTLHN:LD8:VGC:01 (ioc-las-bts) - TMO - IP1
-    LTLHN:LD10:VGC:01 (ioc-las-bts) - TMO - IP2
-    LTLHN:LD2:VGC:01 (ioc-las-bts) - TMO - IP3
-    LTLHN:LD6:VGC:01 (ioc-las-bts) - RIX - qRIXS
-    LTLH:LD4:VGC:01 (ioc-las-bts) - RIX - ChemRIXS
-    LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
-    LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
+        LTLHN:LD8:VGC:01 (ioc-las-bts) - TMO - IP1
+        LTLHN:LD10:VGC:01 (ioc-las-bts) - TMO - IP2
+        LTLHN:LD2:VGC:01 (ioc-las-bts) - TMO - IP3
+        LTLHN:LD6:VGC:01 (ioc-las-bts) - RIX - qRIXS
+        LTLHN:LD4:VGC:01 (ioc-las-bts) - RIX - ChemRIXS
+        LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
+        LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
+
+    The following *will be* sourced from plc-las-bts:
+
+    LSS Shutter Request
+        LTLHN:LS1:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS5:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS8:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+
+    LSS Shutter State - Open
+        LTLHN:LS1:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS5:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS8:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+
+    LSS Shutter State - Closed
+        LTLHN:LS1:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS5:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS8:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
     """
 
     # Linear motors (ioc-las-bts-mcs1)
@@ -103,7 +107,7 @@ class BtpsPrototypeSimulator(PVGroup):
     m6 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m6", user_limits=(-95, 95))
     m8 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m8", user_limits=(-300, 300))
 
-    # Rotary motors
+    # Goniometers
     m3 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m3", user_limits=(0, 0))
     m5 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m5", user_limits=(0, 0))
     m9 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m9", user_limits=(0, 0))


### PR DESCRIPTION
To be used for automated checkout of protection system functionality; more on the way...

* MSTA handling
* User-facing "raise alarm severity now!" settings

Will have to consider how simulation mode fits in with disparate data sources (EPICS vs internal in the vacuum PLC; some are moving from EK9000 there)

Notes
------
* Convention on which stats plugin is to be used?
    * Intend to do arraycounter checking for "is it alive" rather than looking at the pre-calculated rate
* TODO: Double-check PV sources and data types
* General idea:
    * PLC, IOC running in simulation mode
    * pytest to parametrize state and validate invalid parameters cause shutter closure
    * Check bypass functionality
    * Check data store validity