### PR TITLE
REF/ENH: add full set of BTPS PVs for BTMS simulations

### DIFF
--- a/simioc/db/areadetector.py
+++ b/simioc/db/areadetector.py
@@ -1,0 +1,32 @@
+import random
+
+import caproto.server
+from caproto.server import PVGroup, pvproperty
+
+
+class StatsPlugin(PVGroup):
+    """
+    Minimal AreaDetector stats plugin stand-in.
+
+    BTPS will check the array counter update rate and centroid values.
+    """
+
+    enable = pvproperty(value=1, name="SimEnable")
+    array_counter = pvproperty(value=0, name="ArrayCounter_RBV")
+    centroid_x = pvproperty(value=0.0, name="CentroidX_RBV")
+    centroid_y = pvproperty(value=0.0, name="CentroidY_RBV")
+    total = pvproperty(value=0.0, name="Total_RBV")
+
+    @enable.scan(period=1)
+    async def enable(
+        self,
+        instance: caproto.ChannelInteger,
+        async_lib: caproto.server.AsyncLibraryLayer,
+    ):
+        if self.enable.value == 0:
+            return
+
+        await self.array_counter.write(value=self.array_counter.value + 1)
+        await self.centroid_x.write(value=random.random())
+        await self.centroid_y.write(value=random.random())
+        await self.total.write(value=random.random())

--- a/simioc/db/areadetector.py
+++ b/simioc/db/areadetector.py
@@ -13,8 +13,8 @@ class StatsPlugin(PVGroup):
 
     enable = pvproperty(value=1, name="SimEnable")
     array_counter = pvproperty(value=0, name="ArrayCounter_RBV")
-    centroid_x = pvproperty(value=0.0, name="CentroidX_RBV")
-    centroid_y = pvproperty(value=0.0, name="CentroidY_RBV")
+    centroid_x = pvproperty(value=0.0, precision=2, name="CentroidX_RBV")
+    centroid_y = pvproperty(value=0.0, precision=2, name="CentroidY_RBV")
     total = pvproperty(value=0.0, name="Total_RBV")
 
     @enable.scan(period=1)

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -80,7 +80,10 @@ class BtpsMotorsAndCameras(PVGroup):
     m1 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m1", user_limits=(0, 0))
     m4 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m4", user_limits=(0, 2000))
     m7 = SubGroup(
-        Motor, prefix="LAS:BTS:MCS2:01:m7", position=405.0, user_limits=(400, 1446.53)
+        Motor,
+        prefix="LAS:BTS:MCS2:01:m7",
+        position=405.0,
+        user_limits=(400, 1446.53),
     )
 
     # Rotary motors
@@ -117,11 +120,17 @@ class RangeComparison(PVGroup):
 
     # Configuration settings:
     low = pvproperty_from_pytmc(
-        name="Low", io="io", doc="Configurable lower bound for the value range",
+        name="Low",
+        io="io",
+        doc="Configurable lower bound for the value range",
     )
-    nominal = pvproperty_from_pytmc(name="Nominal", io="io", doc="The nominal value",)
+    nominal = pvproperty_from_pytmc(
+        name="Nominal", io="io", doc="The nominal value",
+    )
     high = pvproperty_from_pytmc(
-        name="High", io="io", doc="Configurable upper bound for the value range",
+        name="High",
+        io="io",
+        doc="Configurable upper bound for the value range",
     )
     inclusive = pvproperty_from_pytmc(
         name="Inclusive",
@@ -133,26 +142,42 @@ class RangeComparison(PVGroup):
 class CentroidConfig(PVGroup):
     """BTPS camera centroid range comparison."""
 
-    centroid_x = SubGroup(RangeComparison, prefix="CenterX:", doc="Centroid X range")
-    centroid_y = SubGroup(RangeComparison, prefix="CenterY:", doc="Centroid Y range")
+    centroid_x = SubGroup(
+        RangeComparison, prefix="CenterX:", doc="Centroid X range"
+    )
+    centroid_y = SubGroup(
+        RangeComparison, prefix="CenterY:", doc="Centroid Y range"
+    )
 
 
 class SourceConfig(PVGroup):
     """BTPS per-(source, destination) configuration settings and state."""
 
     name_ = pvproperty_from_pytmc(
-        name="Name", io="input", doc="Source name", value="name", max_length=255,
+        name="Name",
+        io="input",
+        doc="Source name",
+        value="name",
+        max_length=255,
     )
     far_field = SubGroup(CentroidConfig, prefix="FF", doc="Far field centroid")
-    near_field = SubGroup(CentroidConfig, prefix="NF", doc="Near field centroid")
-    goniometer = SubGroup(RangeComparison, prefix="Goniometer:", doc="Goniometer stage")
+    near_field = SubGroup(
+        CentroidConfig, prefix="NF", doc="Near field centroid"
+    )
+    goniometer = SubGroup(
+        RangeComparison, prefix="Goniometer:", doc="Goniometer stage"
+    )
     linear = SubGroup(RangeComparison, prefix="Linear:", doc="Linear stage")
     rotary = SubGroup(RangeComparison, prefix="Rotary:", doc="Rotary stage")
     entry_valve_ready = pvproperty_from_pytmc(
-        name="EntryValveReady", io="input", doc="Entry valve is open and ready",
+        name="EntryValveReady",
+        io="input",
+        doc="Entry valve is open and ready",
     )
 
-    checks_ok = pvproperty_from_pytmc(name="ChecksOK", io="input", doc="Check summary")
+    checks_ok = pvproperty_from_pytmc(
+        name="ChecksOK", io="input", doc="Check summary"
+    )
     data_valid = pvproperty_from_pytmc(
         name="Valid", io="input", doc="Data validity summary"
     )
@@ -162,14 +187,26 @@ class DestinationConfig(PVGroup):
     """BTPS per-destination configuration settings and state."""
 
     name_ = pvproperty_from_pytmc(
-        name="Name", io="input", doc="Destination name", value="name", max_length=255,
+        name="Name",
+        io="input",
+        doc="Destination name",
+        value="name",
+        max_length=255,
     )
-    source1 = SubGroup(SourceConfig, prefix="SRC:01:", doc="Settings for source 1")
-    source3 = SubGroup(SourceConfig, prefix="SRC:03:", doc="Settings for source 3")
-    source4 = SubGroup(SourceConfig, prefix="SRC:04:", doc="Settings for source 4")
+    source1 = SubGroup(
+        SourceConfig, prefix="SRC:01:", doc="Settings for source 1"
+    )
+    source3 = SubGroup(
+        SourceConfig, prefix="SRC:03:", doc="Settings for source 3"
+    )
+    source4 = SubGroup(
+        SourceConfig, prefix="SRC:04:", doc="Settings for source 4"
+    )
     # exit_valve = SubGroup(VGC, prefix="DestValve", doc="Exit valve for the destination")
     exit_valve_ready = pvproperty_from_pytmc(
-        name="ExitValveReady", io="input", doc="Exit valve is open and ready",
+        name="ExitValveReady",
+        io="input",
+        doc="Exit valve is open and ready",
     )
 
 
@@ -207,7 +244,9 @@ class ShutterSafety(PVGroup):
     )
 
     acknowledge = pvproperty_from_pytmc(
-        name="Acknowledge", io="io", doc="User acknowledgement of latched fault",
+        name="Acknowledge",
+        io="io",
+        doc="User acknowledgement of latched fault",
     )
 
     override = pvproperty_from_pytmc(
@@ -215,7 +254,9 @@ class ShutterSafety(PVGroup):
     )
 
     lss_open_request = pvproperty_from_pytmc(
-        name="LSS:OpenRequest", io="input", doc="Output request to LSS open shutter",
+        name="LSS:OpenRequest",
+        io="input",
+        doc="Output request to LSS open shutter",
     )
 
     safe_to_open = pvproperty_from_pytmc(
@@ -228,11 +269,19 @@ class BtpsState(PVGroup):
     Beam Transport Protection System (BTPS) State
     """
 
-    config = SubGroup(GlobalConfig, prefix="Config:", doc="Global configuration")
+    config = SubGroup(
+        GlobalConfig, prefix="Config:", doc="Global configuration"
+    )
 
-    shutter1 = SubGroup(ShutterSafety, prefix="Shutter:01:", doc="Source Shutter 1")
-    shutter3 = SubGroup(ShutterSafety, prefix="Shutter:03:", doc="Source Shutter 3")
-    shutter4 = SubGroup(ShutterSafety, prefix="Shutter:04:", doc="Source Shutter 4")
+    shutter1 = SubGroup(
+        ShutterSafety, prefix="Shutter:01:", doc="Source Shutter 1"
+    )
+    shutter3 = SubGroup(
+        ShutterSafety, prefix="Shutter:03:", doc="Source Shutter 3"
+    )
+    shutter4 = SubGroup(
+        ShutterSafety, prefix="Shutter:04:", doc="Source Shutter 4"
+    )
 
     dest1 = SubGroup(DestinationConfig, prefix="DEST:01:", doc="Destination 1")
     dest2 = SubGroup(DestinationConfig, prefix="DEST:02:", doc="Destination 2")

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -72,14 +72,44 @@ class BtpsMotorsAndCameras(PVGroup):
     )
 
     # Rotary motors
-    m2: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m2", user_limits=(0, 0))
-    m6: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m6", user_limits=(-95, 95))
-    m8: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m8", user_limits=(-300, 300))
+    m2: Motor = SubGroup(
+        SmarActMotor,
+        prefix="LAS:BTS:MCS2:01:m2",
+        user_limits=(0, 0),
+        velocity=100.0,
+    )
+    m6: Motor = SubGroup(
+        SmarActMotor,
+        prefix="LAS:BTS:MCS2:01:m6",
+        user_limits=(-95, 95),
+        velocity=100.0,
+    )
+    m8: Motor = SubGroup(
+        SmarActMotor,
+        prefix="LAS:BTS:MCS2:01:m8",
+        user_limits=(-300, 300),
+        velocity=100.0,
+    )
 
     # Goniometers
-    m3: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m3", user_limits=(0, 0))
-    m5: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m5", user_limits=(0, 0))
-    m9: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m9", user_limits=(0, 0))
+    m3: Motor = SubGroup(
+        SmarActMotor,
+        prefix="LAS:BTS:MCS2:01:m3",
+        user_limits=(0, 0),
+        velocity=100.0,
+    )
+    m5: Motor = SubGroup(
+        SmarActMotor,
+        prefix="LAS:BTS:MCS2:01:m5",
+        user_limits=(0, 0),
+        velocity=100.0,
+    )
+    m9: Motor = SubGroup(
+        SmarActMotor,
+        prefix="LAS:BTS:MCS2:01:m9",
+        user_limits=(0, 0),
+        velocity=100.0,
+    )
 
     nf1: StatsPlugin = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:01:Stats2:")
     nf3: StatsPlugin = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:01:Stats2:")

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -210,7 +210,12 @@ class SourceConfig(PVGroup):
         enum_strings=["Data Invalid", "Data Valid"],
     )
 
-    async def simulate(self, state: BtpsState, destination: DestinationConfig):
+    async def simulate(
+        self,
+        state: BtpsState,
+        motors: BtpsMotorsAndCameras,
+        destination: DestinationConfig,
+    ):
         """Simulate and update state."""
 
 
@@ -246,7 +251,7 @@ class DestinationConfig(PVGroup):
     async def simulate(self, state: BtpsState, motors: BtpsMotorsAndCameras):
         """Simulate and update state."""
         for source in self.sources:
-            await source.simulate(state, self)
+            await source.simulate(state, motors, self)
 
 
 class GlobalConfig(PVGroup):

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -230,29 +230,29 @@ class DestinationConfig(PVGroup):
     """BTPS per-destination configuration settings and state."""
 
     name_ = pvproperty(
-        name="Name_RBV",
+        name="BTPS:Name_RBV",
         doc="Destination name",
         value="name",
         max_length=255,
     )
-    source1: SourceConfig = SubGroup(
+    ls1: SourceConfig = SubGroup(
         SourceConfig,
-        prefix="SRC:01:",
-        doc="Settings for source 1"
+        prefix="LS1:BTPS:",
+        doc="Settings for source LS1, bay 1"
     )
-    source3: SourceConfig = SubGroup(
+    ls5: SourceConfig = SubGroup(
         SourceConfig,
-        prefix="SRC:03:",
-        doc="Settings for source 3"
+        prefix="LS5:BTPS:",
+        doc="Settings for source LS5, bay 3"
     )
-    source4: SourceConfig = SubGroup(
+    ls8: SourceConfig = SubGroup(
         SourceConfig,
-        prefix="SRC:04:",
-        doc="Settings for source 4"
+        prefix="LS8:BTPS:",
+        doc="Settings for source LS8, bay 4"
     )
     # exit_valve = SubGroup(VGC, prefix="DestValve", doc="Exit valve for the destination")
     exit_valve_ready = pvproperty(
-        name="ExitValveReady_RBV",
+        name="BTPS:ExitValveReady_RBV",
         doc="Exit valve is open and ready",
         dtype=ChannelType.ENUM,
         enum_strings=["Not ready", "Ready"],
@@ -262,9 +262,9 @@ class DestinationConfig(PVGroup):
     def sources(self) -> Dict[int, SourceConfig]:
         """Destination configurations."""
         return {
-            1: self.source1,
-            3: self.source3,
-            4: self.source4,
+            1: self.ls1,
+            5: self.ls5,
+            8: self.ls8,
         }
 
     async def simulate(self, state: BtpsState, motors: BtpsMotorsAndCameras):
@@ -436,17 +436,38 @@ class BtsGateValves(PVGroup):
         LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
         LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
     """
-    source1 = SubGroup(VGC, prefix="LTLHN:LS1:VGC:01")
-    source3 = SubGroup(VGC, prefix="LTLHN:LS5:VGC:01")
-    source4 = SubGroup(VGC, prefix="LTLHN:LS8:VGC:01")
+    ls1 = SubGroup(VGC, prefix="LTLHN:LS1:VGC:01")
+    ls5 = SubGroup(VGC, prefix="LTLHN:LS5:VGC:01")
+    ls8 = SubGroup(VGC, prefix="LTLHN:LS8:VGC:01")
 
-    dest1 = SubGroup(VGC, prefix="LTLHN:LD8:VGC:01")  # TMO - IP1
-    dest2 = SubGroup(VGC, prefix="LTLHN:LD10:VGC:01")  # TMO - IP2
-    dest3 = SubGroup(VGC, prefix="LTLHN:LD2:VGC:01")  # TMO - IP3
-    dest4 = SubGroup(VGC, prefix="LTLHN:LD6:VGC:01")  # RIX - qRIXS
-    dest5 = SubGroup(VGC, prefix="LTLHN:LD4:VGC:01")  # RIX - ChemRIXS
-    dest6 = SubGroup(VGC, prefix="LTLHN:LD14:VGC:01")  # XPP
-    dest7 = SubGroup(VGC, prefix="LTLHN:LD9:VGC:01")  # Laser Lab
+    ld2 = SubGroup(VGC, prefix="LTLHN:LD2:VGC:01")  # TMO - IP3
+    ld4 = SubGroup(VGC, prefix="LTLHN:LD4:VGC:01")  # RIX - ChemRIXS
+    ld6 = SubGroup(VGC, prefix="LTLHN:LD6:VGC:01")  # RIX - qRIXS
+    ld8 = SubGroup(VGC, prefix="LTLHN:LD8:VGC:01")  # TMO - IP1
+    ld9 = SubGroup(VGC, prefix="LTLHN:LD9:VGC:01")  # Laser Lab
+    ld10 = SubGroup(VGC, prefix="LTLHN:LD10:VGC:01")  # TMO - IP2
+    ld14 = SubGroup(VGC, prefix="LTLHN:LD14:VGC:01")  # XPP
+
+    @property
+    def by_source(self) -> Dict[int, VGC]:
+        return {
+            1: self.ls1,
+            5: self.ls5,
+            8: self.ls8,
+        }
+
+    @property
+    def by_destination(self) -> Dict[int, VGC]:
+        return {
+            2: self.ld2,
+            4: self.ld4,
+            6: self.ld6,
+            8: self.ld8,
+            9: self.ld9,
+            10: self.ld10,
+            14: self.ld14,
+
+        }
 
 
 class LssShutters(PVGroup):
@@ -473,9 +494,9 @@ class LssShutters(PVGroup):
         LTLHN:LS5:LST:LSS_RBV (ioc-las-bts)
         LTLHN:LS8:LST:LSS_RBV (ioc-las-bts)
     """
-    source1 = SubGroup(LssShutter, prefix="LTLHN:LS1:LST:")
-    source3 = SubGroup(LssShutter, prefix="LTLHN:LS5:LST:")
-    source4 = SubGroup(LssShutter, prefix="LTLHN:LS8:LST:")
+    ls1 = SubGroup(LssShutter, prefix="LTLHN:LS1:LST:")
+    ls5 = SubGroup(LssShutter, prefix="LTLHN:LS5:LST:")
+    ls8 = SubGroup(LssShutter, prefix="LTLHN:LS8:LST:")
 
 
 class BtpsState(PVGroup):
@@ -485,56 +506,91 @@ class BtpsState(PVGroup):
 
     config = SubGroup(GlobalConfig, prefix="Config:", doc="Global configuration")
 
-    shutter1: ShutterSafety = SubGroup(
+    ls1: ShutterSafety = SubGroup(
         ShutterSafety,
-        prefix="Shutter:01:",
-        doc="Source Shutter 1",
+        prefix="LS1:BTPS:",
+        doc="Source Shutter LS1 (bay 1)",
     )
-    shutter3: ShutterSafety = SubGroup(
+    ls5: ShutterSafety = SubGroup(
         ShutterSafety,
-        prefix="Shutter:03:",
-        doc="Source Shutter 3",
+        prefix="LS5:BTPS:",
+        doc="Source Shutter LS5 (bay 3)",
     )
-    shutter4: ShutterSafety = SubGroup(
+    ls8: ShutterSafety = SubGroup(
         ShutterSafety,
-        prefix="Shutter:04:",
-        doc="Source Shutter 4",
+        prefix="LS8:BTPS:",
+        doc="Source Shutter LS8 (bay 4)",
     )
 
-    dest1: DestinationConfig = SubGroup(
+    ld1: DestinationConfig = SubGroup(
         DestinationConfig,
-        prefix="DEST:01:",
+        prefix="LD1:",
         doc="Destination 1",
     )
-    dest2: DestinationConfig = SubGroup(
+    ld2: DestinationConfig = SubGroup(
         DestinationConfig,
-        prefix="DEST:02:",
+        prefix="LD2:",
         doc="Destination 2",
     )
-    dest3: DestinationConfig = SubGroup(
+    ld3: DestinationConfig = SubGroup(
         DestinationConfig,
-        prefix="DEST:03:",
+        prefix="LD3:",
         doc="Destination 3",
     )
-    dest4: DestinationConfig = SubGroup(
+    ld4: DestinationConfig = SubGroup(
         DestinationConfig,
-        prefix="DEST:04:",
+        prefix="LD4:",
         doc="Destination 4",
     )
-    dest5: DestinationConfig = SubGroup(
+    ld5: DestinationConfig = SubGroup(
         DestinationConfig,
-        prefix="DEST:05:",
+        prefix="LD5:",
         doc="Destination 5",
     )
-    dest6: DestinationConfig = SubGroup(
+    ld6: DestinationConfig = SubGroup(
         DestinationConfig,
-        prefix="DEST:06:",
+        prefix="LD6:",
         doc="Destination 6",
     )
-    dest7: DestinationConfig = SubGroup(
+    ld7: DestinationConfig = SubGroup(
         DestinationConfig,
-        prefix="DEST:07:",
+        prefix="LD7:",
         doc="Destination 7",
+    )
+    ld8: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="LD8:",
+        doc="Destination 8",
+    )
+    ld9: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="LD9:",
+        doc="Destination 9",
+    )
+    ld10: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="LD10:",
+        doc="Destination 10",
+    )
+    ld11: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="LD11:",
+        doc="Destination 11",
+    )
+    ld12: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="LD12:",
+        doc="Destination 12",
+    )
+    ld13: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="LD13:",
+        doc="Destination 13",
+    )
+    ld14: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="LD14:",
+        doc="Destination 14",
     )
 
     sim_enable = pvproperty(value=1, name="SimEnable", record="bo")
@@ -569,17 +625,24 @@ class BtpsState(PVGroup):
     @property
     def shutters(self) -> Dict[int, ShutterSafety]:
         """Source shutters."""
-        return {1: self.shutter1, 3: self.shutter3, 4: self.shutter4}
+        return {1: self.ls1, 5: self.ls5, 8: self.ls8}
 
     @property
     def destinations(self) -> Dict[int, DestinationConfig]:
         """Destination configurations."""
         return {
-            1: self.dest1,
-            2: self.dest2,
-            3: self.dest3,
-            4: self.dest4,
-            5: self.dest5,
-            6: self.dest6,
-            7: self.dest7,
+            1: self.ld1,
+            2: self.ld2,
+            3: self.ld3,
+            4: self.ld4,
+            5: self.ld5,
+            6: self.ld6,
+            7: self.ld7,
+            8: self.ld8,
+            9: self.ld9,
+            10: self.ld10,
+            11: self.ld11,
+            12: self.ld12,
+            13: self.ld13,
+            14: self.ld14,
         }

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -1,0 +1,243 @@
+"""
+BTPS Simulator "database" PVGroups for reuse.
+"""
+
+from caproto.server import PVGroup, SubGroup
+
+from ..db.areadetector import StatsPlugin
+from ..db.motor import Motor
+from ..db.utils import pvproperty_from_pytmc
+
+
+class BtpsMotorsAndCameras(PVGroup):
+    """
+    A simulator for key motion and camera PVs in the control system.
+
+    Listed PVs do not include the default "SIM:" prefix.
+
+    PVs
+    ---
+    Motor - Linear
+        LAS:BTS:MCS2:01:m1 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m4 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m7 (ioc-las-bts-mcs1)
+
+    Motor - Rotary
+        LAS:BTS:MCS2:01:m2 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m6 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m8 (ioc-las-bts-mcs1)
+
+    Motor - Goniometer
+        LAS:BTS:MCS2:01:m3 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m5 (ioc-las-bts-mcs1)
+        LAS:BTS:MCS2:01:m9 (ioc-las-bts-mcs1)
+
+    NF Camera
+        LAS:LHN:BAY1:CAM:01 (ioc-lhn-bay1-nf-01)
+        LAS:LHN:BAY3:CAM:01 (?, assumed)
+        LAS:LHN:BAY4:CAM:01 (ioc-lhn-bay4-nf-01)
+
+    FF Camera
+        LAS:LHN:BAY1:CAM:02 (ioc-lhn-bay1-ff-01)
+        LAS:LHN:BAY3:CAM:02 (?, assumed)
+        LAS:LHN:BAY4:CAM:02 (ioc-lhn-bay4-ff-01)
+
+    The following are sourced from plc-las-bts:
+
+    Source Gate Valve
+        LTLHN:LS1:VGC:01 (ioc-las-bts)
+        LTLHN:LS5:VGC:01 (ioc-las-bts)
+        LTLHN:LS8:VGC:01 (ioc-las-bts)
+
+    Destination Gate Valve PV
+        LTLHN:LD8:VGC:01 (ioc-las-bts) - TMO - IP1
+        LTLHN:LD10:VGC:01 (ioc-las-bts) - TMO - IP2
+        LTLHN:LD2:VGC:01 (ioc-las-bts) - TMO - IP3
+        LTLHN:LD6:VGC:01 (ioc-las-bts) - RIX - qRIXS
+        LTLHN:LD4:VGC:01 (ioc-las-bts) - RIX - ChemRIXS
+        LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
+        LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
+
+    The following *will be* sourced from plc-las-bts:
+
+    LSS Shutter Request
+        LTLHN:LS1:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS5:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS8:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+
+    LSS Shutter State - Open
+        LTLHN:LS1:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS5:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS8:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+
+    LSS Shutter State - Closed
+        LTLHN:LS1:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS5:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+        LTLHN:LS8:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
+    """
+
+    # Linear motors (ioc-las-bts-mcs1)
+    m1 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m1", user_limits=(0, 0))
+    m4 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m4", user_limits=(0, 2000))
+    m7 = SubGroup(
+        Motor, prefix="LAS:BTS:MCS2:01:m7", position=405.0, user_limits=(400, 1446.53)
+    )
+
+    # Rotary motors
+    m2 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m2", user_limits=(0, 0))
+    m6 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m6", user_limits=(-95, 95))
+    m8 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m8", user_limits=(-300, 300))
+
+    # Goniometers
+    m3 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m3", user_limits=(0, 0))
+    m5 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m5", user_limits=(0, 0))
+    m9 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m9", user_limits=(0, 0))
+
+    nf_cam_bay1 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:01:Stats2:")
+    nf_cam_bay3 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:01:Stats2:")
+    nf_cam_bay4 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:01:Stats2:")
+
+    ff_cam_bay1 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:02:Stats2:")
+    ff_cam_bay3 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:02:Stats2:")
+    ff_cam_bay4 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:02:Stats2:")
+
+
+class RangeComparison(PVGroup):
+    """BTPS single value range comparison check."""
+
+    value = pvproperty_from_pytmc(
+        name="Value", io="input", doc="Current value from the control system",
+    )
+    in_range = pvproperty_from_pytmc(
+        name="InRange", io="input", doc="Is the value currently in range?",
+    )
+    input_valid = pvproperty_from_pytmc(
+        name="Valid", io="input", doc="Is the value considered valid?",
+    )
+
+    # Configuration settings:
+    low = pvproperty_from_pytmc(
+        name="Low", io="io", doc="Configurable lower bound for the value range",
+    )
+    nominal = pvproperty_from_pytmc(name="Nominal", io="io", doc="The nominal value",)
+    high = pvproperty_from_pytmc(
+        name="High", io="io", doc="Configurable upper bound for the value range",
+    )
+    inclusive = pvproperty_from_pytmc(
+        name="Inclusive",
+        io="io",
+        doc="Is the value comparison exclusive or inclusive?",
+    )
+
+
+class CentroidConfig(PVGroup):
+    """BTPS camera centroid range comparison."""
+
+    centroid_x = SubGroup(RangeComparison, prefix="CenterX:", doc="Centroid X range")
+    centroid_y = SubGroup(RangeComparison, prefix="CenterY:", doc="Centroid Y range")
+
+
+class SourceConfig(PVGroup):
+    """BTPS per-(source, destination) configuration settings and state."""
+
+    name_ = pvproperty_from_pytmc(
+        name="Name", io="input", doc="Source name", value="name", max_length=255,
+    )
+    far_field = SubGroup(CentroidConfig, prefix="FF", doc="Far field centroid")
+    near_field = SubGroup(CentroidConfig, prefix="NF", doc="Near field centroid")
+    goniometer = SubGroup(RangeComparison, prefix="Goniometer:", doc="Goniometer stage")
+    linear = SubGroup(RangeComparison, prefix="Linear:", doc="Linear stage")
+    rotary = SubGroup(RangeComparison, prefix="Rotary:", doc="Rotary stage")
+    entry_valve_ready = pvproperty_from_pytmc(
+        name="EntryValveReady", io="input", doc="Entry valve is open and ready",
+    )
+
+    checks_ok = pvproperty_from_pytmc(name="ChecksOK", io="input", doc="Check summary")
+    data_valid = pvproperty_from_pytmc(
+        name="Valid", io="input", doc="Data validity summary"
+    )
+
+
+class DestinationConfig(PVGroup):
+    """BTPS per-destination configuration settings and state."""
+
+    name_ = pvproperty_from_pytmc(
+        name="Name", io="input", doc="Destination name", value="name", max_length=255,
+    )
+    source1 = SubGroup(SourceConfig, prefix="SRC:01:", doc="Settings for source 1")
+    source3 = SubGroup(SourceConfig, prefix="SRC:03:", doc="Settings for source 3")
+    source4 = SubGroup(SourceConfig, prefix="SRC:04:", doc="Settings for source 4")
+    # exit_valve = SubGroup(VGC, prefix="DestValve", doc="Exit valve for the destination")
+    exit_valve_ready = pvproperty_from_pytmc(
+        name="ExitValveReady", io="input", doc="Exit valve is open and ready",
+    )
+
+
+class GlobalConfig(PVGroup):
+    """BTPS global configuration settings."""
+
+    max_frame_time = pvproperty_from_pytmc(
+        name="MaxFrameTime",
+        io="io",
+        doc=(
+            "Maximum time between frame updates in seconds to be considered "
+            "'valid' data"
+        ),
+    )
+
+    min_centroid_change = pvproperty_from_pytmc(
+        name="MinPixelChange",
+        io="io",
+        doc=(
+            "Minimal change (in pixels) for camera image sum to be "
+            "considered valid"
+        ),
+    )
+
+
+class ShutterSafety(PVGroup):
+    """BTPS per-source shutter safety status."""
+
+    open_request = pvproperty_from_pytmc(
+        name="UserOpen", io="io", doc="User request to open/close shutter",
+    )
+
+    latched_error = pvproperty_from_pytmc(
+        name="Error", io="input", doc="Latched error",
+    )
+
+    acknowledge = pvproperty_from_pytmc(
+        name="Acknowledge", io="io", doc="User acknowledgement of latched fault",
+    )
+
+    override = pvproperty_from_pytmc(
+        name="Override", io="io", doc="BTPS advanced override mode",
+    )
+
+    lss_open_request = pvproperty_from_pytmc(
+        name="LSS:OpenRequest", io="input", doc="Output request to LSS open shutter",
+    )
+
+    safe_to_open = pvproperty_from_pytmc(
+        name="Safe", io="input", doc="BTPS safe to open indicator",
+    )
+
+
+class BtpsState(PVGroup):
+    """
+    Beam Transport Protection System (BTPS) State
+    """
+
+    config = SubGroup(GlobalConfig, prefix="Config:", doc="Global configuration")
+
+    shutter1 = SubGroup(ShutterSafety, prefix="Shutter:01:", doc="Source Shutter 1")
+    shutter3 = SubGroup(ShutterSafety, prefix="Shutter:03:", doc="Source Shutter 3")
+    shutter4 = SubGroup(ShutterSafety, prefix="Shutter:04:", doc="Source Shutter 4")
+
+    dest1 = SubGroup(DestinationConfig, prefix="DEST:01:", doc="Destination 1")
+    dest2 = SubGroup(DestinationConfig, prefix="DEST:02:", doc="Destination 2")
+    dest3 = SubGroup(DestinationConfig, prefix="DEST:03:", doc="Destination 3")
+    dest4 = SubGroup(DestinationConfig, prefix="DEST:04:", doc="Destination 4")
+    dest5 = SubGroup(DestinationConfig, prefix="DEST:05:", doc="Destination 5")
+    dest6 = SubGroup(DestinationConfig, prefix="DEST:06:", doc="Destination 6")
+    dest7 = SubGroup(DestinationConfig, prefix="DEST:07:", doc="Destination 7")

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -332,6 +332,10 @@ class DestinationConfig(PVGroup):
         value=1,
     )
 
+    def __init__(self, *args, destination_name: str = "Unknown", **kwargs):
+        super().__init__(*args, **kwargs)
+        self.name_._data["value"] = destination_name
+
     @property
     def sources(self) -> Dict[int, SourceConfig]:
         """Destination configurations."""
@@ -686,6 +690,7 @@ class BtpsState(PVGroup):
         DestinationConfig,
         prefix="LD2:",
         doc="Destination 2",
+        destination_name="TMO IP3",
     )
     ld3: DestinationConfig = SubGroup(
         DestinationConfig,
@@ -696,6 +701,7 @@ class BtpsState(PVGroup):
         DestinationConfig,
         prefix="LD4:",
         doc="Destination 4",
+        destination_name="RIX ChemRIXS",
     )
     ld5: DestinationConfig = SubGroup(
         DestinationConfig,
@@ -706,6 +712,7 @@ class BtpsState(PVGroup):
         DestinationConfig,
         prefix="LD6:",
         doc="Destination 6",
+        destination_name="RIX QRIXS",
     )
     ld7: DestinationConfig = SubGroup(
         DestinationConfig,
@@ -716,16 +723,19 @@ class BtpsState(PVGroup):
         DestinationConfig,
         prefix="LD8:",
         doc="Destination 8",
+        destination_name="TMO IP1",
     )
     ld9: DestinationConfig = SubGroup(
         DestinationConfig,
         prefix="LD9:",
         doc="Destination 9",
+        destination_name="Laser Lab",
     )
     ld10: DestinationConfig = SubGroup(
         DestinationConfig,
         prefix="LD10:",
         doc="Destination 10",
+        destination_name="TMO IP2",
     )
     ld11: DestinationConfig = SubGroup(
         DestinationConfig,
@@ -746,6 +756,7 @@ class BtpsState(PVGroup):
         DestinationConfig,
         prefix="LD14:",
         doc="Destination 14",
+        destination_name="XPP",
     )
 
     sim_enable = pvproperty(value=1, name="SimEnable", record="bo")

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -395,7 +395,8 @@ class BtpsAllCameraStatus(PVGroup):
 class LssShutter(PVGroup):
     """Beam transport system shutter interface via ioc-las-bts."""
 
-    async def _put_request(self, instance, value: int):
+    async def _put_request(self, instance, value: str):
+        value = self.readback.enum_strings.index(value)
         await self.parent.opened.write(bool(value))
         await self.parent.closed.write(not bool(value))
         await self.readback.write(bool(value))

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -83,9 +83,9 @@ class BtpsMotorsAndCameras(PVGroup):
     """
 
     # Linear motors (ioc-las-bts-mcs1)
-    m1 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m1", user_limits=(0, 0))
-    m4 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m4", user_limits=(0, 2000))
-    m7 = SubGroup(
+    m1: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m1", user_limits=(0, 0))
+    m4: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m4", user_limits=(0, 2000))
+    m7: Motor = SubGroup(
         Motor,
         prefix="LAS:BTS:MCS2:01:m7",
         position=405.0,
@@ -93,22 +93,22 @@ class BtpsMotorsAndCameras(PVGroup):
     )
 
     # Rotary motors
-    m2 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m2", user_limits=(0, 0))
-    m6 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m6", user_limits=(-95, 95))
-    m8 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m8", user_limits=(-300, 300))
+    m2: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m2", user_limits=(0, 0))
+    m6: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m6", user_limits=(-95, 95))
+    m8: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m8", user_limits=(-300, 300))
 
     # Goniometers
-    m3 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m3", user_limits=(0, 0))
-    m5 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m5", user_limits=(0, 0))
-    m9 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m9", user_limits=(0, 0))
+    m3: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m3", user_limits=(0, 0))
+    m5: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m5", user_limits=(0, 0))
+    m9: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m9", user_limits=(0, 0))
 
-    nf_cam_bay1 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:01:Stats2:")
-    nf_cam_bay3 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:01:Stats2:")
-    nf_cam_bay4 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:01:Stats2:")
+    nf1: StatsPlugin = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:01:Stats2:")
+    nf3: StatsPlugin = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:01:Stats2:")
+    nf4: StatsPlugin = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:01:Stats2:")
 
-    ff_cam_bay1 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:02:Stats2:")
-    ff_cam_bay3 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:02:Stats2:")
-    ff_cam_bay4 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:02:Stats2:")
+    ff1: StatsPlugin = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:02:Stats2:")
+    ff3: StatsPlugin = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:02:Stats2:")
+    ff4: StatsPlugin = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:02:Stats2:")
 
 
 class RangeComparison(PVGroup):
@@ -182,12 +182,19 @@ class RangeComparison(PVGroup):
 
 class CentroidConfig(PVGroup):
     """BTPS camera centroid range comparison."""
-    centroid_x = SubGroup(RangeComparison, prefix="CenterX:", doc="Centroid X range")
-    centroid_y = SubGroup(RangeComparison, prefix="CenterY:", doc="Centroid Y range")
+    centroid_x: RangeComparison = SubGroup(
+        RangeComparison,
+        prefix="CenterX:",
+        doc="Centroid X range",
+    )
+    centroid_y: RangeComparison = SubGroup(
+        RangeComparison,
+        prefix="CenterY:",
+        doc="Centroid Y range",
+    )
 
     async def simulate(self, data_valid: bool = True):
         for check in [self.centroid_x, self.centroid_y]:
-            check = cast(RangeComparison, check)
             await check.simulate()
 
 
@@ -200,11 +207,21 @@ class SourceConfig(PVGroup):
         value="name",
         max_length=255,
     )
-    far_field = SubGroup(CentroidConfig, prefix="FF", doc="Far field centroid")
-    near_field = SubGroup(CentroidConfig, prefix="NF", doc="Near field centroid")
-    goniometer = SubGroup(RangeComparison, prefix="Goniometer:", doc="Goniometer stage")
-    linear = SubGroup(RangeComparison, prefix="Linear:", doc="Linear stage")
-    rotary = SubGroup(RangeComparison, prefix="Rotary:", doc="Rotary stage")
+    far_field: CentroidConfig = SubGroup(
+        CentroidConfig, prefix="FF", doc="Far field centroid"
+    )
+    near_field: CentroidConfig = SubGroup(
+        CentroidConfig, prefix="NF", doc="Near field centroid"
+    )
+    goniometer: RangeComparison = SubGroup(
+        RangeComparison, prefix="Goniometer:", doc="Goniometer stage"
+    )
+    linear: RangeComparison = SubGroup(
+        RangeComparison, prefix="Linear:", doc="Linear stage"
+    )
+    rotary: RangeComparison = SubGroup(
+        RangeComparison, prefix="Rotary:", doc="Rotary stage"
+    )
     entry_valve_ready = pvproperty(
         name="EntryValveReady_RBV",
         doc="Entry valve is open and ready",
@@ -237,8 +254,8 @@ class SourceConfig(PVGroup):
             await check.simulate()
 
         for centroid in [self.near_field, self.far_field]:
-            check = cast(CentroidConfig, check)
-            await check.simulate()
+            centroid = cast(CentroidConfig, centroid)
+            await centroid.simulate()
 
 
 class DestinationConfig(PVGroup):
@@ -250,9 +267,21 @@ class DestinationConfig(PVGroup):
         value="name",
         max_length=255,
     )
-    source1 = SubGroup(SourceConfig, prefix="SRC:01:", doc="Settings for source 1")
-    source3 = SubGroup(SourceConfig, prefix="SRC:03:", doc="Settings for source 3")
-    source4 = SubGroup(SourceConfig, prefix="SRC:04:", doc="Settings for source 4")
+    source1: SourceConfig = SubGroup(
+        SourceConfig,
+        prefix="SRC:01:",
+        doc="Settings for source 1"
+    )
+    source3: SourceConfig = SubGroup(
+        SourceConfig,
+        prefix="SRC:03:",
+        doc="Settings for source 3"
+    )
+    source4: SourceConfig = SubGroup(
+        SourceConfig,
+        prefix="SRC:04:",
+        doc="Settings for source 4"
+    )
     # exit_valve = SubGroup(VGC, prefix="DestValve", doc="Exit valve for the destination")
     exit_valve_ready = pvproperty(
         name="ExitValveReady_RBV",
@@ -386,20 +415,60 @@ class BtpsState(PVGroup):
 
     config = SubGroup(GlobalConfig, prefix="Config:", doc="Global configuration")
 
-    shutter1 = SubGroup(ShutterSafety, prefix="Shutter:01:", doc="Source Shutter 1")
-    shutter3 = SubGroup(ShutterSafety, prefix="Shutter:03:", doc="Source Shutter 3")
-    shutter4 = SubGroup(ShutterSafety, prefix="Shutter:04:", doc="Source Shutter 4")
+    shutter1: ShutterSafety = SubGroup(
+        ShutterSafety,
+        prefix="Shutter:01:",
+        doc="Source Shutter 1",
+    )
+    shutter3: ShutterSafety = SubGroup(
+        ShutterSafety,
+        prefix="Shutter:03:",
+        doc="Source Shutter 3",
+    )
+    shutter4: ShutterSafety = SubGroup(
+        ShutterSafety,
+        prefix="Shutter:04:",
+        doc="Source Shutter 4",
+    )
 
-    dest1 = SubGroup(DestinationConfig, prefix="DEST:01:", doc="Destination 1")
-    dest2 = SubGroup(DestinationConfig, prefix="DEST:02:", doc="Destination 2")
-    dest3 = SubGroup(DestinationConfig, prefix="DEST:03:", doc="Destination 3")
-    dest4 = SubGroup(DestinationConfig, prefix="DEST:04:", doc="Destination 4")
-    dest5 = SubGroup(DestinationConfig, prefix="DEST:05:", doc="Destination 5")
-    dest6 = SubGroup(DestinationConfig, prefix="DEST:06:", doc="Destination 6")
-    dest7 = SubGroup(DestinationConfig, prefix="DEST:07:", doc="Destination 7")
+    dest1: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="DEST:01:",
+        doc="Destination 1",
+    )
+    dest2: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="DEST:02:",
+        doc="Destination 2",
+    )
+    dest3: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="DEST:03:",
+        doc="Destination 3",
+    )
+    dest4: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="DEST:04:",
+        doc="Destination 4",
+    )
+    dest5: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="DEST:05:",
+        doc="Destination 5",
+    )
+    dest6: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="DEST:06:",
+        doc="Destination 6",
+    )
+    dest7: DestinationConfig = SubGroup(
+        DestinationConfig,
+        prefix="DEST:07:",
+        doc="Destination 7",
+    )
 
     sim_enable = pvproperty(value=1, name="SimEnable", record="bo")
-    camera_times = SubGroup(BtpsAllCameraStatus, prefix="Chk:")
+    camera_times: BtpsAllCameraStatus = SubGroup(BtpsAllCameraStatus, prefix="Chk:")
 
     @sim_enable.scan(period=1, use_scan_field=True)
     async def sim_enable(

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -516,7 +516,11 @@ class BtpsState(PVGroup):
     Beam Transport Protection System (BTPS) State
     """
 
-    config = SubGroup(GlobalConfig, prefix="Config:", doc="Global configuration")
+    config = SubGroup(
+        GlobalConfig,
+        prefix="BTPS:Config:",
+        doc="Global configuration settings for BTPS"
+    )
 
     ls1: ShutterSafety = SubGroup(
         ShutterSafety,

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -64,22 +64,6 @@ class BtpsMotorsAndCameras(PVGroup):
         LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
         LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
 
-    The following *will be* sourced from plc-las-bts:
-
-    LSS Shutter Request
-        LTLHN:LS1:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS5:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS8:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-
-    LSS Shutter State - Open
-        LTLHN:LS1:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS5:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS8:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-
-    LSS Shutter State - Closed
-        LTLHN:LS1:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS5:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS8:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
     """
 
     # Linear motors (ioc-las-bts-mcs1)
@@ -406,6 +390,67 @@ class BtpsAllCameraStatus(PVGroup):
     ff1 = SubGroup(BtpsCameraStatus, prefix="FF1:")
     ff3 = SubGroup(BtpsCameraStatus, prefix="FF3:")
     ff4 = SubGroup(BtpsCameraStatus, prefix="FF4:")
+
+
+class LssShutter(PVGroup):
+    """Beam transport system shutter interface via ioc-las-bts."""
+    request = pvproperty_with_rbv(
+        name="REQ",
+        value=0,
+        doc="User request to open",
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    opened = pvproperty(
+        name="OPN_RBV",
+        value=0,
+        doc="Open status",
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    closed = pvproperty(
+        name="CLS_RBV",
+        value=0,
+        doc="Closed status",
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    permission = pvproperty(
+        name="LSS_RBV",
+        value=0,
+        doc="LSS Permission status",
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+
+
+class LssShutters(PVGroup):
+    """
+    Shutter readback status and request status.
+
+    LSS Shutter Request
+        LTLHN:LS1:LST:REQ_RBV (ioc-las-bts)
+        LTLHN:LS5:LST:REQ_RBV (ioc-las-bts)
+        LTLHN:LS8:LST:REQ_RBV (ioc-las-bts)
+
+    LSS Shutter State - Open
+        LTLHN:LS1:LST:OPN_RBV (ioc-las-bts)
+        LTLHN:LS5:LST:OPN_RBV (ioc-las-bts)
+        LTLHN:LS8:LST:OPN_RBV (ioc-las-bts)
+
+    LSS Shutter State - Closed
+        LTLHN:LS1:LST:CLS_RBV (ioc-las-bts)
+        LTLHN:LS5:LST:CLS_RBV (ioc-las-bts)
+        LTLHN:LS8:LST:CLS_RBV (ioc-las-bts)
+
+    LSS Permission
+        LTLHN:LS1:LST:LSS_RBV (ioc-las-bts)
+        LTLHN:LS5:LST:LSS_RBV (ioc-las-bts)
+        LTLHN:LS8:LST:LSS_RBV (ioc-las-bts)
+    """
+    source1 = SubGroup(LssShutter, prefix="LTLHN:LS1:LST:")
+    source3 = SubGroup(LssShutter, prefix="LTLHN:LS5:LST:")
+    source4 = SubGroup(LssShutter, prefix="LTLHN:LS8:LST:")
 
 
 class BtpsState(PVGroup):

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -324,6 +324,13 @@ class DestinationConfig(PVGroup):
         dtype=ChannelType.ENUM,
         enum_strings=["Not ready", "Ready"],
     )
+    yield_control = pvproperty_with_rbv(
+        name="BTPS:YieldsControl",
+        doc="Destination yields control to others",
+        dtype=ChannelType.ENUM,
+        enum_strings=["Using beam", "Yielding"],
+        value=1,
+    )
 
     @property
     def sources(self) -> Dict[int, SourceConfig]:

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -363,6 +363,14 @@ class GlobalConfig(PVGroup):
         enum_strings=["FALSE", "TRUE"],
     )
 
+    maintenance = pvproperty_with_rbv(
+        name="Maintenance",
+        value=0,
+        doc="System maintenance mode indicator",
+        dtype=ChannelType.ENUM,
+        enum_strings=["Normal operation", "Maintenance"],
+    )
+
     max_frame_time = pvproperty_with_rbv(
         name="MaxFrameTime",
         precision=2,

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -287,12 +287,15 @@ class GlobalConfig(PVGroup):
 
     system_override = pvproperty_with_rbv(
         name="SystemOverride",
-        value=0.0,
+        value="FALSE",
         doc="System override for when BTPS gets in the way",
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
     )
 
     max_frame_time = pvproperty_with_rbv(
         name="MaxFrameTime",
+        precision=2,
         value=0.0,
         doc=(
             "Maximum time between frame updates in seconds to be considered "

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -13,6 +13,7 @@ from caproto.server import PVGroup, SubGroup, pvproperty
 from .areadetector import StatsPlugin
 from .motor import Motor
 from .utils import pvproperty_with_rbv, write_if_differs
+from .valve import VGC
 
 
 class BtpsMotorsAndCameras(PVGroup):
@@ -47,23 +48,6 @@ class BtpsMotorsAndCameras(PVGroup):
         LAS:LHN:BAY1:CAM:02 (ioc-lhn-bay1-ff-01)
         LAS:LHN:BAY3:CAM:02 (?, assumed)
         LAS:LHN:BAY4:CAM:02 (ioc-lhn-bay4-ff-01)
-
-    The following are sourced from plc-las-bts:
-
-    Source Gate Valve
-        LTLHN:LS1:VGC:01 (ioc-las-bts)
-        LTLHN:LS5:VGC:01 (ioc-las-bts)
-        LTLHN:LS8:VGC:01 (ioc-las-bts)
-
-    Destination Gate Valve PV
-        LTLHN:LD8:VGC:01 (ioc-las-bts) - TMO - IP1
-        LTLHN:LD10:VGC:01 (ioc-las-bts) - TMO - IP2
-        LTLHN:LD2:VGC:01 (ioc-las-bts) - TMO - IP3
-        LTLHN:LD6:VGC:01 (ioc-las-bts) - RIX - qRIXS
-        LTLHN:LD4:VGC:01 (ioc-las-bts) - RIX - ChemRIXS
-        LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
-        LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
-
     """
 
     # Linear motors (ioc-las-bts-mcs1)
@@ -430,6 +414,39 @@ class LssShutter(PVGroup):
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
+
+
+class BtsGateValves(PVGroup):
+    """
+    Gate valves (VGC, non-legacy)
+
+    The following are sourced from plc-las-bts:
+
+    Source Gate Valve
+        LTLHN:LS1:VGC:01 (ioc-las-bts)
+        LTLHN:LS5:VGC:01 (ioc-las-bts)
+        LTLHN:LS8:VGC:01 (ioc-las-bts)
+
+    Destination Gate Valve PV
+        LTLHN:LD8:VGC:01 (ioc-las-bts) - TMO - IP1
+        LTLHN:LD10:VGC:01 (ioc-las-bts) - TMO - IP2
+        LTLHN:LD2:VGC:01 (ioc-las-bts) - TMO - IP3
+        LTLHN:LD6:VGC:01 (ioc-las-bts) - RIX - qRIXS
+        LTLHN:LD4:VGC:01 (ioc-las-bts) - RIX - ChemRIXS
+        LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
+        LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
+    """
+    source1 = SubGroup(VGC, prefix="LTLHN:LS1:VGC:01")
+    source3 = SubGroup(VGC, prefix="LTLHN:LS5:VGC:01")
+    source4 = SubGroup(VGC, prefix="LTLHN:LS8:VGC:01")
+
+    dest1 = SubGroup(VGC, prefix="LTLHN:LD8:VGC:01")  # TMO - IP1
+    dest2 = SubGroup(VGC, prefix="LTLHN:LD10:VGC:01")  # TMO - IP2
+    dest3 = SubGroup(VGC, prefix="LTLHN:LD2:VGC:01")  # TMO - IP3
+    dest4 = SubGroup(VGC, prefix="LTLHN:LD6:VGC:01")  # RIX - qRIXS
+    dest5 = SubGroup(VGC, prefix="LTLHN:LD4:VGC:01")  # RIX - ChemRIXS
+    dest6 = SubGroup(VGC, prefix="LTLHN:LD14:VGC:01")  # XPP
+    dest7 = SubGroup(VGC, prefix="LTLHN:LD9:VGC:01")  # Laser Lab
 
 
 class LssShutters(PVGroup):

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -11,7 +11,7 @@ from caproto import ChannelType
 from caproto.server import PVGroup, SubGroup, pvproperty
 
 from .areadetector import StatsPlugin
-from .motor import Motor
+from .motor import Motor, SmarActMotor
 from .utils import pvproperty_with_rbv, write_if_differs
 from .valve import VGC
 
@@ -51,10 +51,18 @@ class BtpsMotorsAndCameras(PVGroup):
     """
 
     # Linear motors (ioc-las-bts-mcs1)
-    m1: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m1", user_limits=(0, 0))
-    m4: Motor = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m4", user_limits=(0, 2000))
-    m7: Motor = SubGroup(
-        Motor,
+    m1: SmarActMotor = SubGroup(
+        SmarActMotor,
+        prefix="LAS:BTS:MCS2:01:m1",
+        user_limits=(0, 0),
+    )
+    m4: SmarActMotor = SubGroup(
+        SmarActMotor,
+        prefix="LAS:BTS:MCS2:01:m4",
+        user_limits=(0, 2000),
+    )
+    m7: SmarActMotor = SubGroup(
+        SmarActMotor,
         prefix="LAS:BTS:MCS2:01:m7",
         position=405.0,
         user_limits=(400, 1446.53),

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -55,17 +55,20 @@ class BtpsMotorsAndCameras(PVGroup):
         SmarActMotor,
         prefix="LAS:BTS:MCS2:01:m1",
         user_limits=(0, 0),
+        velocity=100.0,
     )
     m4: SmarActMotor = SubGroup(
         SmarActMotor,
         prefix="LAS:BTS:MCS2:01:m4",
         user_limits=(0, 2000),
+        velocity=100.0,
     )
     m7: SmarActMotor = SubGroup(
         SmarActMotor,
         prefix="LAS:BTS:MCS2:01:m7",
         position=405.0,
         user_limits=(400, 1446.53),
+        velocity=100.0,
     )
 
     # Rotary motors

--- a/simioc/db/btps.py
+++ b/simioc/db/btps.py
@@ -394,12 +394,19 @@ class BtpsAllCameraStatus(PVGroup):
 
 class LssShutter(PVGroup):
     """Beam transport system shutter interface via ioc-las-bts."""
+
+    async def _put_request(self, instance, value: int):
+        await self.parent.opened.write(bool(value))
+        await self.parent.closed.write(not bool(value))
+        await self.readback.write(bool(value))
+
     request = pvproperty_with_rbv(
         name="REQ",
         value=0,
         doc="User request to open",
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        put=_put_request,
     )
     opened = pvproperty(
         name="OPN_RBV",

--- a/simioc/db/motor.py
+++ b/simioc/db/motor.py
@@ -3,6 +3,8 @@ import caproto
 from caproto.server import PVGroup, SubGroup, get_pv_pair_wrapper, pvproperty
 from caproto.server.records import MotorFields, register_record
 
+from .utils import pvproperty_with_rbv
+
 
 async def broadcast_precision_to_fields(record):
     """Update precision of all fields to that of the given record."""
@@ -143,6 +145,43 @@ class Motor(PVGroup):
             self.motor, async_lib, self.defaults,
             tick_rate_hz=self.tick_rate_hz,
         )
+
+
+class SmarActMotor(Motor):
+    ptype = pvproperty_with_rbv(name=":PTYPE", value=0, doc="Positioner type")
+    step_voltage = pvproperty(
+        name=":STEP_VOLTAGE", value=0.0, doc="Voltage for sawtooth (0-100V)"
+    )
+    # Frequency of steps
+    step_freq = pvproperty(name=":STEP_FREQ", value=0.0, doc="Sawtooth drive frequency")
+    # Number of steps per step forward, backward command
+    jog_step_size = pvproperty(
+        name=":STEP_COUNT", value=0, doc="Number of steps per FWD/BWD command"
+    )
+    # Jog forward
+    jog_fwd = pvproperty(name=":STEP_FORWARD", value=0, doc="Jog the stage forward")
+    # Jog backward
+    jog_rev = pvproperty(name=":STEP_REVERSE", value=0, doc="Jog the stage backward")
+    # Total number of steps counted
+    total_step_count = pvproperty(
+        name=":TOTAL_STEP_COUNT",
+        value=0,
+        doc="Current open loop step count",
+        read_only=True,
+    )
+    # Reset steps ("home")
+    step_clear_cmd = pvproperty(
+        name=":CLEAR_COUNT", value=0, doc="Clear the current step count"
+    )
+    # Scan move
+    scan_pos = pvproperty(
+        name=":SCAN_POS", value=0, doc="Set current piezo voltage (in 16 bit ADC steps)"
+    )
+    scan_move = pvproperty(
+        name=":SCAN_MOVE",
+        value=0,
+        doc="Set current piezo voltage (in 16 bit ADC steps)",
+    )
 
 
 class BeckhoffAxisPLC(PVGroup):

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -8,7 +8,8 @@ from typing import cast
 from caproto import ChannelData
 from caproto.server import AsyncLibraryLayer, PVGroup, SubGroup, pvproperty
 
-from ..db.btps import BtpsMotorsAndCameras, BtpsState, RangeComparison
+from ..db.btps import (BtpsMotorsAndCameras, BtpsState, LssShutters,
+                       RangeComparison)
 from .utils import main
 
 
@@ -21,14 +22,6 @@ class SourceDestinationConfiguration:
     rotary: float
     goniometer: float
 
-
-# GVL_BTPS.fbDestinations[1](sName:='TMO IP1', fbDestinationValve:=GVL_BTS_VAC.fb_LD8_VGC);
-# GVL_BTPS.fbDestinations[2](sName:='TMO IP2', fbDestinationValve:=GVL_BTS_VAC.fb_LD10_VGC);
-# GVL_BTPS.fbDestinations[3](sName:='TMO IP3', fbDestinationValve:=GVL_BTS_VAC.fb_LD2_VGC);
-# GVL_BTPS.fbDestinations[4](sName:='RIX qRIXS', fbDestinationValve:=GVL_BTS_VAC.fb_LD6_VGC);
-# GVL_BTPS.fbDestinations[5](sName:='RIX ChemRIXS', fbDestinationValve:=GVL_BTS_VAC.fb_LD4_VGC);
-# GVL_BTPS.fbDestinations[6](sName:='XPP', fbDestinationValve:=GVL_BTS_VAC.fb_LD14_VGC);
-# GVL_BTPS.fbDestinations[7](sName:='Laser Lab', fbDestinationValve:=GVL_BTS_VAC.fb_LD9_VGC);
 
 sample_config = sum(
     (
@@ -105,6 +98,7 @@ class BtpsSimulator(PVGroup):
 
     motors: BtpsMotorsAndCameras = SubGroup(BtpsMotorsAndCameras, prefix="")
     state: BtpsState = SubGroup(BtpsState, prefix="LTLHN:BTPS:")
+    shutters: LssShutters = SubGroup(LssShutters, prefix="")
     load_config = pvproperty(name="LTLHN:BTPS:Sim:LoadConfig", value=0)
 
     @load_config.startup

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -8,8 +8,8 @@ from typing import cast
 from caproto import ChannelData
 from caproto.server import AsyncLibraryLayer, PVGroup, SubGroup, pvproperty
 
-from ..db.btps import (BtpsMotorsAndCameras, BtpsState, LssShutters,
-                       RangeComparison)
+from ..db.btps import (BtpsMotorsAndCameras, BtpsState, BtsGateValves,
+                       LssShutters, RangeComparison)
 from .utils import main
 
 
@@ -99,6 +99,7 @@ class BtpsSimulator(PVGroup):
     motors: BtpsMotorsAndCameras = SubGroup(BtpsMotorsAndCameras, prefix="")
     state: BtpsState = SubGroup(BtpsState, prefix="LTLHN:BTPS:")
     shutters: LssShutters = SubGroup(LssShutters, prefix="")
+    gate_valves: BtsGateValves = SubGroup(BtsGateValves, prefix="")
     load_config = pvproperty(name="LTLHN:BTPS:Sim:LoadConfig", value=0)
 
     @load_config.startup

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -103,16 +103,15 @@ class BtpsSimulator(PVGroup):
     Listed PVs do not include the default "SIM:" prefix.
     """
 
-    motors = SubGroup(BtpsMotorsAndCameras, prefix="")
-    state = SubGroup(BtpsState, prefix="LTLHN:BTPS:")
+    motors: BtpsMotorsAndCameras = SubGroup(BtpsMotorsAndCameras, prefix="")
+    state: BtpsState = SubGroup(BtpsState, prefix="LTLHN:BTPS:")
     load_config = pvproperty(name="LTLHN:BTPS:Sim:LoadConfig", value=0)
 
     @load_config.startup
     async def load_config(self, instance: ChannelData, async_lib: AsyncLibraryLayer):
         print("Loading sample config...")
-        state = cast(BtpsState, self.state)
         for conf in sample_config:
-            dest = state.destinations[conf.destination]
+            dest = self.state.destinations[conf.destination]
             source = dest.sources[conf.source]
 
             for range_, nominal in [

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -2,124 +2,22 @@
 BTPS Simulator IOC for unit and integration tests.
 """
 
-import random
-from caproto.server import PVGroup, SubGroup, pvproperty
+from caproto.server import PVGroup, SubGroup
 
-from ..db.motor import Motor
+from ..db.btps import BtpsMotorsAndCameras, BtpsState
 from .utils import main
 
 
-class StatsPlugin(PVGroup):
+class BtpsSimulator(PVGroup):
     """
-    Minimal AreaDetector stats plugin stand-in.
-
-    BTPS will check the array counter update rate and centroid values.
-    """
-    enable = pvproperty(value=1, name="SimEnable")
-    array_counter = pvproperty(value=0, name="ArrayCounter_RBV")
-    centroid_x = pvproperty(value=0.0, name="CentroidX_RBV")
-    centroid_y = pvproperty(value=0.0, name="CentroidY_RBV")
-
-    @enable.scan(period=1)
-    async def enable(self, instance, async_lib):
-        if self.enable.value == 0:
-            return
-       
-        await self.array_counter.write(value=self.array_counter.value + 1)
-        await self.centroid_x.write(value=random.random())
-        await self.centroid_y.write(value=random.random())
-
-
-class BtpsPrototypeSimulator(PVGroup):
-    """
-    A simulator for key BTPS PVs in the control system.
+    A simulator for BTPS motors, cameras, and range logic.
 
     Listed PVs do not include the default "SIM:" prefix.
-
-    PVs
-    ---
-    Motor - Linear
-        LAS:BTS:MCS2:01:m1 (ioc-las-bts-mcs1)
-        LAS:BTS:MCS2:01:m4 (ioc-las-bts-mcs1)
-        LAS:BTS:MCS2:01:m7 (ioc-las-bts-mcs1)
-
-    Motor - Rotary
-        LAS:BTS:MCS2:01:m2 (ioc-las-bts-mcs1)
-        LAS:BTS:MCS2:01:m6 (ioc-las-bts-mcs1)
-        LAS:BTS:MCS2:01:m8 (ioc-las-bts-mcs1)
-
-    Motor - Goniometer
-        LAS:BTS:MCS2:01:m3 (ioc-las-bts-mcs1)
-        LAS:BTS:MCS2:01:m5 (ioc-las-bts-mcs1)
-        LAS:BTS:MCS2:01:m9 (ioc-las-bts-mcs1)
-
-    NF Camera
-        LAS:LHN:BAY1:CAM:01 (ioc-lhn-bay1-nf-01)
-        LAS:LHN:BAY3:CAM:01 (?, assumed)
-        LAS:LHN:BAY4:CAM:01 (ioc-lhn-bay4-nf-01)
-
-    FF Camera
-        LAS:LHN:BAY1:CAM:02 (ioc-lhn-bay1-ff-01)
-        LAS:LHN:BAY3:CAM:02 (?, assumed)
-        LAS:LHN:BAY4:CAM:02 (ioc-lhn-bay4-ff-01)
-
-    The following are sourced from plc-las-bts:
-
-    Source Gate Valve
-        LTLHN:LS1:VGC:01 (ioc-las-bts)
-        LTLHN:LS5:VGC:01 (ioc-las-bts)
-        LTLHN:LS8:VGC:01 (ioc-las-bts)
-
-    Destination Gate Valve PV
-        LTLHN:LD8:VGC:01 (ioc-las-bts) - TMO - IP1
-        LTLHN:LD10:VGC:01 (ioc-las-bts) - TMO - IP2
-        LTLHN:LD2:VGC:01 (ioc-las-bts) - TMO - IP3
-        LTLHN:LD6:VGC:01 (ioc-las-bts) - RIX - qRIXS
-        LTLHN:LD4:VGC:01 (ioc-las-bts) - RIX - ChemRIXS
-        LTLHN:LD14:VGC:01 (ioc-las-bts) - XPP
-        LTLHN:LD9:VGC:01 (ioc-las-bts) - Laser Lab
-
-    The following *will be* sourced from plc-las-bts:
-
-    LSS Shutter Request
-        LTLHN:LS1:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS5:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS8:LST:REQ (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-
-    LSS Shutter State - Open
-        LTLHN:LS1:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS5:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS8:LST:OPN (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-
-    LSS Shutter State - Closed
-        LTLHN:LS1:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS5:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
-        LTLHN:LS8:LST:CLS (ioc-las-lhn-bhc-05 -> ioc-las-bts)
     """
 
-    # Linear motors (ioc-las-bts-mcs1)
-    m1 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m1", user_limits=(0, 0))
-    m4 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m4", user_limits=(0, 2000))
-    m7 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m7", position=405.0, user_limits=(400, 1446.53))
-
-    # Rotary motors
-    m2 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m2", user_limits=(0, 0))
-    m6 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m6", user_limits=(-95, 95))
-    m8 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m8", user_limits=(-300, 300))
-
-    # Goniometers
-    m3 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m3", user_limits=(0, 0))
-    m5 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m5", user_limits=(0, 0))
-    m9 = SubGroup(Motor, prefix="LAS:BTS:MCS2:01:m9", user_limits=(0, 0))
-
-    nf_cam_bay1 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:01:Stats1:")
-    nf_cam_bay3 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:01:Stats1:")
-    nf_cam_bay4 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:01:Stats1:")
-
-    ff_cam_bay1 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY1:CAM:02:Stats1:")
-    ff_cam_bay3 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY3:CAM:02:Stats1:")
-    ff_cam_bay4 = SubGroup(StatsPlugin, prefix="LAS:LHN:BAY4:CAM:02:Stats1:")
+    motors = SubGroup(BtpsMotorsAndCameras, prefix="")
+    state = SubGroup(BtpsState, prefix="LTLHN:BTPS:")
 
 
 if __name__ == "__main__":
-    main(cls=BtpsPrototypeSimulator, default_prefix="SIM:")
+    main(cls=BtpsSimulator, default_prefix="SIM:")

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -23,62 +23,113 @@ class SourceDestinationConfiguration:
     goniometer: float
 
 
+# Bottom destinations (rough top centers, inside chamber)
+BOTTOM_PORTS = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+]
+TOP_PORTS = [
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+]
+
+
+def guess_position_for_port(dest: int) -> float:
+    """
+    Make a guess at a linear stage position given the destination port number.
+
+    Parameters
+    ----------
+    dest : int
+        The destination port number.
+
+    Returns
+    -------
+    float
+        Linear stage position guess.
+    """
+    # 8.5" spacing per side
+    # 215.9 mm port-to-port
+    port_spacing_mm = 215.9
+    top_start = 30.0000
+    bottom_start = top_start + port_spacing_mm / 2
+
+    if dest in TOP_PORTS:
+        port_index = TOP_PORTS.index(dest)
+        start = top_start
+    else:
+        port_index = BOTTOM_PORTS.index(dest)
+        start = bottom_start
+
+    return start + port_index * port_spacing_mm
+
+
 sample_config = sum(
     (
         [
-            # TMO IP1
+            # TMO IP1 (LD8)
             SourceDestinationConfiguration(
                 source=source,
-                destination=1,
-                linear=1357.0,
+                destination=8,
+                linear=guess_position_for_port(8),
                 rotary=-89.7,
                 goniometer=0.0,
             ),
-            # TMO IP2
+            # TMO IP2 (LD10)
+            SourceDestinationConfiguration(
+                source=source,
+                destination=10,
+                linear=guess_position_for_port(10),
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+            # TMO IP3 (LD2)
             SourceDestinationConfiguration(
                 source=source,
                 destination=2,
-                linear=1000.,
+                linear=guess_position_for_port(2),
                 rotary=-89.0,
                 goniometer=0.0,
             ),
-            # TMO IP3
-            SourceDestinationConfiguration(
-                source=source,
-                destination=3,
-                linear=750.,
-                rotary=-89.0,
-                goniometer=0.0,
-            ),
-            # qRIXS
-            SourceDestinationConfiguration(
-                source=source,
-                destination=4,
-                linear=500.,
-                rotary=-89.0,
-                goniometer=0.0,
-            ),
-            # ChemRIXS
-            SourceDestinationConfiguration(
-                source=source,
-                destination=5,
-                linear=250.,
-                rotary=-89.0,
-                goniometer=0.0,
-            ),
-            # XPP
+            # qRIXS (LD6)
             SourceDestinationConfiguration(
                 source=source,
                 destination=6,
-                linear=59.0,
+                linear=guess_position_for_port(6),
                 rotary=-89.0,
                 goniometer=0.0,
             ),
-            # Laser lab
+            # ChemRIXS (LD4)
             SourceDestinationConfiguration(
                 source=source,
-                destination=7,
-                linear=0.,
+                destination=4,
+                linear=guess_position_for_port(4),
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+            # XPP (LD14)
+            SourceDestinationConfiguration(
+                source=source,
+                destination=14,
+                linear=guess_position_for_port(14),
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+            # Laser lab (LD9)
+            SourceDestinationConfiguration(
+                source=source,
+                destination=9,
+                linear=guess_position_for_port(9),
                 rotary=-89.0,
                 goniometer=0.0,
             ),

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -166,7 +166,7 @@ class BtpsSimulator(PVGroup):
                 (source.rotary, conf.rotary),
             ]:
                 range_ = cast(RangeComparison, range_)
-                await range_.set_nominal(nominal)
+                await range_.set_nominal(nominal, atol=5.0)
 
 
 if __name__ == "__main__":

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -2,11 +2,98 @@
 BTPS Simulator IOC for unit and integration tests.
 """
 
+import dataclasses
+from typing import cast
+
 from caproto import ChannelData
 from caproto.server import AsyncLibraryLayer, PVGroup, SubGroup, pvproperty
 
-from ..db.btps import BtpsMotorsAndCameras, BtpsState
+from ..db.btps import BtpsMotorsAndCameras, BtpsState, RangeComparison
 from .utils import main
+
+
+@dataclasses.dataclass
+class SourceDestinationConfiguration:
+    source: int
+    destination: int
+
+    linear: float
+    rotary: float
+    goniometer: float
+
+
+# GVL_BTPS.fbDestinations[1](sName:='TMO IP1', fbDestinationValve:=GVL_BTS_VAC.fb_LD8_VGC);
+# GVL_BTPS.fbDestinations[2](sName:='TMO IP2', fbDestinationValve:=GVL_BTS_VAC.fb_LD10_VGC);
+# GVL_BTPS.fbDestinations[3](sName:='TMO IP3', fbDestinationValve:=GVL_BTS_VAC.fb_LD2_VGC);
+# GVL_BTPS.fbDestinations[4](sName:='RIX qRIXS', fbDestinationValve:=GVL_BTS_VAC.fb_LD6_VGC);
+# GVL_BTPS.fbDestinations[5](sName:='RIX ChemRIXS', fbDestinationValve:=GVL_BTS_VAC.fb_LD4_VGC);
+# GVL_BTPS.fbDestinations[6](sName:='XPP', fbDestinationValve:=GVL_BTS_VAC.fb_LD14_VGC);
+# GVL_BTPS.fbDestinations[7](sName:='Laser Lab', fbDestinationValve:=GVL_BTS_VAC.fb_LD9_VGC);
+
+sample_config = sum(
+    (
+        [
+            # TMO IP1
+            SourceDestinationConfiguration(
+                source=source,
+                destination=1,
+                linear=1357.0,
+                rotary=-89.7,
+                goniometer=0.0,
+            ),
+            # TMO IP2
+            SourceDestinationConfiguration(
+                source=source,
+                destination=2,
+                linear=1000.,
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+            # TMO IP3
+            SourceDestinationConfiguration(
+                source=source,
+                destination=3,
+                linear=750.,
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+            # qRIXS
+            SourceDestinationConfiguration(
+                source=source,
+                destination=4,
+                linear=500.,
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+            # ChemRIXS
+            SourceDestinationConfiguration(
+                source=source,
+                destination=5,
+                linear=250.,
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+            # XPP
+            SourceDestinationConfiguration(
+                source=source,
+                destination=6,
+                linear=59.0,
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+            # Laser lab
+            SourceDestinationConfiguration(
+                source=source,
+                destination=7,
+                linear=0.,
+                rotary=-89.0,
+                goniometer=0.0,
+            ),
+        ]
+        for source in [1, 3, 4]
+    ),
+    []
+)
 
 
 class BtpsSimulator(PVGroup):
@@ -22,7 +109,19 @@ class BtpsSimulator(PVGroup):
 
     @load_config.startup
     async def load_config(self, instance: ChannelData, async_lib: AsyncLibraryLayer):
-        ...
+        print("Loading sample config...")
+        state = cast(BtpsState, self.state)
+        for conf in sample_config:
+            dest = state.destinations[conf.destination]
+            source = dest.sources[conf.source]
+
+            for range_, nominal in [
+                (source.linear, conf.linear),
+                (source.goniometer, conf.goniometer),
+                (source.rotary, conf.rotary),
+            ]:
+                range_ = cast(RangeComparison, range_)
+                await range_.set_nominal(nominal)
 
 
 if __name__ == "__main__":

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -83,7 +83,7 @@ sample_config = sum(
                 goniometer=0.0,
             ),
         ]
-        for source in [1, 3, 4]
+        for source in [1, 5, 8]
     ),
     []
 )
@@ -97,7 +97,7 @@ class BtpsSimulator(PVGroup):
     """
 
     motors: BtpsMotorsAndCameras = SubGroup(BtpsMotorsAndCameras, prefix="")
-    state: BtpsState = SubGroup(BtpsState, prefix="LTLHN:BTPS:")
+    state: BtpsState = SubGroup(BtpsState, prefix="LTLHN:")
     shutters: LssShutters = SubGroup(LssShutters, prefix="")
     gate_valves: BtsGateValves = SubGroup(BtsGateValves, prefix="")
     load_config = pvproperty(name="LTLHN:BTPS:Sim:LoadConfig", value=0)

--- a/simioc/ioc/btps.py
+++ b/simioc/ioc/btps.py
@@ -2,7 +2,8 @@
 BTPS Simulator IOC for unit and integration tests.
 """
 
-from caproto.server import PVGroup, SubGroup
+from caproto import ChannelData
+from caproto.server import AsyncLibraryLayer, PVGroup, SubGroup, pvproperty
 
 from ..db.btps import BtpsMotorsAndCameras, BtpsState
 from .utils import main
@@ -17,6 +18,11 @@ class BtpsSimulator(PVGroup):
 
     motors = SubGroup(BtpsMotorsAndCameras, prefix="")
     state = SubGroup(BtpsState, prefix="LTLHN:BTPS:")
+    load_config = pvproperty(name="LTLHN:BTPS:Sim:LoadConfig", value=0)
+
+    @load_config.startup
+    async def load_config(self, instance: ChannelData, async_lib: AsyncLibraryLayer):
+        ...
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Source

* Addition of simulation functionality required for BTMS testing
* Reflection of ophyd Devices into caproto PVGroups: https://github.com/pcdshub/pcdsdevices/blob/master/pcdsdevices/lasers/btps.py

Closes #11 

cc @slactjohnson 