### PR TITLE
ENH: add valves from pcdsdevices.valves + converter tool

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = .git,__pycache__,build,dist,versioneer.py,simioc/_version.py
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203, E501

--- a/simioc/db/valve.py
+++ b/simioc/db/valve.py
@@ -1,0 +1,1054 @@
+from caproto import ChannelType
+from caproto.server import PVGroup, pvproperty
+
+from .utils import pvproperty_with_rbv
+
+
+class Stopper(PVGroup):
+    open_limit = pvproperty(
+        name=":OPEN",
+        value=0,
+        doc="Reads 1 if the stopper is out, at the open limit.",
+        read_only=True,
+    )
+    closed_limit = pvproperty(
+        name=":CLOSE",
+        value=0,
+        doc="Reads 1 if the stopper is in, at the closed limit.",
+        read_only=True,
+    )
+    command = pvproperty(
+        name=":CMD", value=0, doc="Put here to command a stopper move.", read_only=False
+    )
+
+
+class GateValve(Stopper, PVGroup):
+    open_limit = pvproperty(name=":OPN_DI", value=0, doc="", read_only=True)
+    closed_limit = pvproperty(name=":CLS_DI", value=0, doc="", read_only=True)
+    command = pvproperty(
+        name=":OPN_SW",
+        value=0,
+        doc="",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock = pvproperty(name=":OPN_OK", value=0, doc="", read_only=True)
+
+
+class PPSStopper(PVGroup):
+    state = pvproperty(
+        name="",
+        value=0,
+        doc="Stopper state summary PV that tells us if it is in, out, or inconsistent.",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+
+
+class VCN(PVGroup):
+    position_readback = pvproperty(
+        name=":POS_RDBK_RBV", value=0, doc="valve position readback", read_only=True
+    )
+    position_control = pvproperty_with_rbv(
+        name=":POS_REQ",
+        value=0,
+        doc="requested positition to control the valve 0-100%",
+        read_only=False,
+    )
+    upper_limit = pvproperty_with_rbv(
+        name=":Limit",
+        value=0,
+        doc="max upper limit position to open the valve 0-100%",
+        read_only=False,
+    )
+    interlock_ok = pvproperty(
+        name=":ILK_OK_RBV",
+        value=0,
+        doc="interlock ok status",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["NOT OK", "OK"],
+    )
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    state = pvproperty_with_rbv(
+        name=":STATE",
+        value=0,
+        doc="Valve state",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=[
+            "Vented",
+            "At Vacuum",
+            "Differential Pressure",
+            "Lost Vacuum",
+            "Ext Fault",
+            "AT Vacuum",
+            "Triggered",
+            "Vacuum Fault",
+            "Close Timeout",
+            "Open Timeout",
+        ],
+    )
+    pos_ao = pvproperty(name=":POS_AO_RBV", value=0, doc="", read_only=True)
+
+
+class VFS(PVGroup):
+    valve_position = pvproperty(
+        name=":POS_STATE_RBV",
+        value=0,
+        doc="Ex: OPEN, CLOSED, MOVING, INVALID, OPEN_F",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPEN", "CLOSED", "MOVING", "INVALID", "OPEN_F"],
+    )
+    vfs_state = pvproperty(
+        name=":STATE_RBV",
+        value=0,
+        doc="Fast Shutter Current State",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=[
+            "Vented",
+            "At Vacuum",
+            "Differential Pressure",
+            "Lost Vacuum",
+            "Ext Fault",
+            "AT Vacuum",
+            "Triggered",
+            "Vacuum Fault",
+            "Close Timeout",
+            "Open Timeout",
+        ],
+    )
+    request_close = pvproperty_with_rbv(
+        name=":CLS_SW",
+        value=0,
+        doc="Request Fast Shutter to Close. When both closeand open are requested, VFS will close.",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+    request_open = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Request Fast Shutter to Open. Requires a risingEPICS signal to open. When both close andopen are requested, VFS will close.",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    reset_vacuum_fault = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Fast Shutter Vacuum Faults: fastsensor triggered, fast sensor turned off.To open VFS, this needs to be reset to TRUEafter a vacuum event.",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    override_mode = pvproperty_with_rbv(
+        name=":OVRD_ON",
+        value=0,
+        doc="Epics Command to set Override mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    override_force_open = pvproperty_with_rbv(
+        name=":FORCE_OPN",
+        value=0,
+        doc="Epics Command to force openthe valve in override mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "FORCE OPEN"],
+    )
+    gfs_name = pvproperty(
+        name=":GFS_RBV",
+        value="",
+        doc="Gauge Fast Sensor Name",
+        read_only=True,
+        max_length=80,
+    )
+    gfs_trigger = pvproperty(
+        name=":TRIG_RBV",
+        value=0,
+        doc="Gauge Fast Sensor Input Trigger",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["TRIG_OFF", "TRIG_ON"],
+    )
+    position_close = pvproperty(
+        name=":CLS_DI_RBV",
+        value=0,
+        doc="Fast Shutter Closed Valve Position",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+    position_open = pvproperty(
+        name=":OPN_DI_RBV",
+        value=0,
+        doc="Fast Shutter Open Valve Position",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "OPEN"],
+    )
+    vac_fault_ok = pvproperty(
+        name=":VAC_FAULT_OK_RBV",
+        value=0,
+        doc="Fast Shutter Vacuum Fault OK Readback",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FAULT", "FAULT OK"],
+    )
+    mps_ok = pvproperty(
+        name=":MPS_FAULT_OK_RBV",
+        value=0,
+        doc="Fast Shutter Fast Fault Output OK",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["MPS FAULT", "MPS OK"],
+    )
+    veto_device = pvproperty(
+        name=":VETO_DEVICE_RBV",
+        value=0,
+        doc="Name of device that can veto this VFS",
+        read_only=True,
+    )
+
+
+class ValveBase(PVGroup):
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock_ok = pvproperty(
+        name=":OPN_OK_RBV",
+        value=0,
+        doc="Valve is OK to Open interlock ",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+    )
+    open_do = pvproperty(
+        name=":OPN_DO_RBV",
+        value=0,
+        doc="PLC Output to Open valve, 1 means 24V on command cable",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+
+
+class VVC(ValveBase, PVGroup):
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock_ok = pvproperty(
+        name=":OPN_OK_RBV",
+        value=0,
+        doc="Valve is OK to Open interlock ",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+    )
+    open_do = pvproperty(
+        name=":OPN_DO_RBV",
+        value=0,
+        doc="PLC Output to Open valve, 1 means 24V on command cable",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    override_status = pvproperty(
+        name=":OVRD_ON_RBV",
+        value=0,
+        doc="Epics Readback on Override mode",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    override_force_open = pvproperty_with_rbv(
+        name=":FORCE_OPN",
+        value=0,
+        doc="Epics Command to force open the valve inoverride mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "FORCE OPEN"],
+    )
+
+
+class VRC(VVC, PVGroup):
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock_ok = pvproperty(
+        name=":OPN_OK_RBV",
+        value=0,
+        doc="Valve is OK to Open interlock ",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+    )
+    open_do = pvproperty(
+        name=":OPN_DO_RBV",
+        value=0,
+        doc="PLC Output to Open valve, 1 means 24V on command cable",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    override_status = pvproperty(
+        name=":OVRD_ON_RBV",
+        value=0,
+        doc="Epics Readback on Override mode",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    override_force_open = pvproperty_with_rbv(
+        name=":FORCE_OPN",
+        value=0,
+        doc="Epics Command to force open the valve inoverride mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "FORCE OPEN"],
+    )
+    state = pvproperty(
+        name=":STATE_RBV",
+        value=0,
+        doc="Valve state",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=[
+            "Vented",
+            "At Vacuum",
+            "Differential Pressure",
+            "Lost Vacuum",
+            "Ext Fault",
+            "AT Vacuum",
+            "Triggered",
+            "Vacuum Fault",
+            "Close Timeout",
+            "Open Timeout",
+        ],
+    )
+    open_limit = pvproperty(
+        name=":OPN_DI_RBV",
+        value=0,
+        doc="Open limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "OPEN"],
+    )
+    closed_limit = pvproperty(
+        name=":CLS_DI_RBV",
+        value=0,
+        doc="Closed limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+
+
+class VGC(VRC, PVGroup):
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock_ok = pvproperty(
+        name=":OPN_OK_RBV",
+        value=0,
+        doc="Valve is OK to Open interlock ",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+    )
+    open_do = pvproperty(
+        name=":OPN_DO_RBV",
+        value=0,
+        doc="PLC Output to Open valve, 1 means 24V on command cable",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    override_status = pvproperty(
+        name=":OVRD_ON_RBV",
+        value=0,
+        doc="Epics Readback on Override mode",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    override_force_open = pvproperty_with_rbv(
+        name=":FORCE_OPN",
+        value=0,
+        doc="Epics Command to force open the valve inoverride mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "FORCE OPEN"],
+    )
+    state = pvproperty(
+        name=":STATE_RBV",
+        value=0,
+        doc="Valve state",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=[
+            "Vented",
+            "At Vacuum",
+            "Differential Pressure",
+            "Lost Vacuum",
+            "Ext Fault",
+            "AT Vacuum",
+            "Triggered",
+            "Vacuum Fault",
+            "Close Timeout",
+            "Open Timeout",
+        ],
+    )
+    open_limit = pvproperty(
+        name=":OPN_DI_RBV",
+        value=0,
+        doc="Open limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "OPEN"],
+    )
+    closed_limit = pvproperty(
+        name=":CLS_DI_RBV",
+        value=0,
+        doc="Closed limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+    diff_press_ok = pvproperty(
+        name=":DP_OK_RBV",
+        value=0,
+        doc="Differential pressure interlock ok",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["DP NOT OK", "DP OK"],
+    )
+    ext_ilk_ok = pvproperty(
+        name=":EXT_ILK_OK_RBV",
+        value=0,
+        doc="External interlock ok",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["NOT OK", "OK"],
+    )
+    at_vac_setpoint = pvproperty_with_rbv(
+        name=":AT_VAC_SP", value=0.0, doc="AT VAC Set point value", read_only=False
+    )
+    setpoint_hysterisis = pvproperty_with_rbv(
+        name=":AT_VAC_HYS", value=0.0, doc="AT VAC Hysteresis", read_only=False
+    )
+    at_vac = pvproperty(
+        name=":AT_VAC_RBV",
+        value=0,
+        doc="at vacuum setpoint is reached",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["NOT AT VAC", "AT VAC"],
+    )
+    error = pvproperty(
+        name=":ERROR_RBV",
+        value=0,
+        doc="Error Present",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["NO ERROR", "ERROR PRESENT"],
+    )
+    mps_state = pvproperty(
+        name=":MPS_FAULT_OK_RBV",
+        value=0,
+        doc="individual valve MPS state for debugging",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["MPS FAULT", "MPS OK"],
+    )
+    interlock_device_upstream = pvproperty(
+        name=":ILK_DEVICE_US_RBV",
+        value="",
+        doc="Upstream vacuum device used forinterlocking this valve",
+        read_only=True,
+        max_length=80,
+    )
+    interlock_device_downstream = pvproperty(
+        name=":ILK_DEVICE_DS_RBV",
+        value="",
+        doc="Downstream vacuum device used forinterlocking this valve",
+        read_only=True,
+        max_length=80,
+    )
+
+
+class VGCLegacy(ValveBase, PVGroup):
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock_ok = pvproperty(
+        name=":OPN_OK_RBV",
+        value=0,
+        doc="Valve is OK to Open interlock ",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+    )
+    open_do = pvproperty(
+        name=":OPN_DO_RBV",
+        value=0,
+        doc="PLC Output to Open valve, 1 means 24V on command cable",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    open_limit = pvproperty(
+        name=":OPN_DI_RBV",
+        value=0,
+        doc="Open limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "OPEN"],
+    )
+    closed_limit = pvproperty(
+        name=":CLS_DI_RBV",
+        value=0,
+        doc="Closed limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+
+
+class VGC_2S(VRC, PVGroup):
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock_ok = pvproperty(
+        name=":OPN_OK_RBV",
+        value=0,
+        doc="Valve is OK to Open interlock ",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+    )
+    open_do = pvproperty(
+        name=":OPN_DO_RBV",
+        value=0,
+        doc="PLC Output to Open valve, 1 means 24V on command cable",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    override_status = pvproperty(
+        name=":OVRD_ON_RBV",
+        value=0,
+        doc="Epics Readback on Override mode",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    override_force_open = pvproperty_with_rbv(
+        name=":FORCE_OPN",
+        value=0,
+        doc="Epics Command to force open the valve inoverride mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "FORCE OPEN"],
+    )
+    state = pvproperty(
+        name=":STATE_RBV",
+        value=0,
+        doc="Valve state",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=[
+            "Vented",
+            "At Vacuum",
+            "Differential Pressure",
+            "Lost Vacuum",
+            "Ext Fault",
+            "AT Vacuum",
+            "Triggered",
+            "Vacuum Fault",
+            "Close Timeout",
+            "Open Timeout",
+        ],
+    )
+    open_limit = pvproperty(
+        name=":OPN_DI_RBV",
+        value=0,
+        doc="Open limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "OPEN"],
+    )
+    closed_limit = pvproperty(
+        name=":CLS_DI_RBV",
+        value=0,
+        doc="Closed limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+    diff_press_ok = pvproperty(
+        name=":DP_OK_RBV",
+        value=0,
+        doc="Differential pressure interlock ok",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["DP NOT OK", "DP OK"],
+    )
+    ext_ilk_ok = pvproperty(
+        name=":EXT_ILK_OK_RBV",
+        value=0,
+        doc="External interlock ok",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["NOT OK", "OK"],
+    )
+    at_vac_setpoint_us = pvproperty_with_rbv(
+        name=":AT_VAC_SP",
+        value=0.0,
+        doc="AT VAC Set point value for the upstream gauge",
+        read_only=False,
+    )
+    setpoint_hysterisis_us = pvproperty_with_rbv(
+        name=":AT_VAC_HYS",
+        value=0.0,
+        doc="AT VAC Hysteresis for the upstream setpoint",
+        read_only=False,
+    )
+    at_vac_setpoint_ds = pvproperty_with_rbv(
+        name=":AT_VAC_SP_DS",
+        value=0,
+        doc="AT VAC Set point value for the downstream gauge",
+        read_only=False,
+    )
+    setpoint_hysterisis_ds = pvproperty_with_rbv(
+        name=":AT_VAC_HYS_DS",
+        value=0,
+        doc="AT VAC Hysteresis for the downstream setpoint",
+        read_only=False,
+    )
+    at_vac = pvproperty(
+        name=":AT_VAC_RBV",
+        value=0,
+        doc="at vacuum setpoint is reached",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["NOT AT VAC", "AT VAC"],
+    )
+    error = pvproperty(
+        name=":ERROR_RBV",
+        value=0,
+        doc="Error Present",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["NO ERROR", "ERROR PRESENT"],
+    )
+    mps_state = pvproperty(
+        name=":MPS_FAULT_OK_RBV",
+        value=0,
+        doc="individual valve MPS state for debugging",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["MPS FAULT", "MPS OK"],
+    )
+    interlock_device_upstream = pvproperty(
+        name=":ILK_DEVICE_US_RBV",
+        value="",
+        doc="Upstream vacuum device used forinterlocking this valve",
+        read_only=True,
+        max_length=80,
+    )
+    interlock_device_downstream = pvproperty(
+        name=":ILK_DEVICE_DS_RBV",
+        value="",
+        doc="Downstream vacuum device used forinterlocking this valve",
+        read_only=True,
+        max_length=80,
+    )
+
+
+class VRCClsLS(VVC, PVGroup):
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock_ok = pvproperty(
+        name=":OPN_OK_RBV",
+        value=0,
+        doc="Valve is OK to Open interlock ",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+    )
+    open_do = pvproperty(
+        name=":OPN_DO_RBV",
+        value=0,
+        doc="PLC Output to Open valve, 1 means 24V on command cable",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    override_status = pvproperty(
+        name=":OVRD_ON_RBV",
+        value=0,
+        doc="Epics Readback on Override mode",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    override_force_open = pvproperty_with_rbv(
+        name=":FORCE_OPN",
+        value=0,
+        doc="Epics Command to force open the valve inoverride mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "FORCE OPEN"],
+    )
+    state = pvproperty(
+        name=":STATE_RBV",
+        value=0,
+        doc="Valve state",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=[
+            "Vented",
+            "At Vacuum",
+            "Differential Pressure",
+            "Lost Vacuum",
+            "Ext Fault",
+            "AT Vacuum",
+            "Triggered",
+            "Vacuum Fault",
+            "Close Timeout",
+            "Open Timeout",
+        ],
+    )
+    closed_limit = pvproperty(
+        name=":CLS_DI_RBV",
+        value=0,
+        doc="Closed limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+
+
+class VVCNO(PVGroup):
+    close_command = pvproperty_with_rbv(
+        name=":CLS_SW",
+        value=0,
+        doc="Epics command to close valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+    close_override = pvproperty_with_rbv(
+        name=":FORCE_CLS",
+        value=0,
+        doc="Epics Command for open the valve in override mode",
+        read_only=False,
+    )
+    override_on = pvproperty_with_rbv(
+        name=":OVRD_ON",
+        value=0,
+        doc="Epics Command to set/reset Override mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    close_ok = pvproperty(
+        name=":CLS_OK_RBV", value=0, doc="used for normally open valves", read_only=True
+    )
+    close_do = pvproperty(
+        name=":CLS_DO_RBV", value=0, doc="PLC Output to close valve", read_only=True
+    )
+
+
+class VRCNO(VVCNO, PVGroup):
+    close_command = pvproperty_with_rbv(
+        name=":CLS_SW",
+        value=0,
+        doc="Epics command to close valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+    close_override = pvproperty_with_rbv(
+        name=":FORCE_CLS",
+        value=0,
+        doc="Epics Command for open the valve in override mode",
+        read_only=False,
+    )
+    override_on = pvproperty_with_rbv(
+        name=":OVRD_ON",
+        value=0,
+        doc="Epics Command to set/reset Override mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    close_ok = pvproperty(
+        name=":CLS_OK_RBV", value=0, doc="used for normally open valves", read_only=True
+    )
+    close_do = pvproperty(
+        name=":CLS_DO_RBV", value=0, doc="PLC Output to close valve", read_only=True
+    )
+    state = pvproperty(
+        name=":STATE_RBV",
+        value=0,
+        doc="Valve state",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=[
+            "Vented",
+            "At Vacuum",
+            "Differential Pressure",
+            "Lost Vacuum",
+            "Ext Fault",
+            "AT Vacuum",
+            "Triggered",
+            "Vacuum Fault",
+            "Close Timeout",
+            "Open Timeout",
+        ],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    open_limit = pvproperty(
+        name=":OPN_DI_RBV",
+        value=0,
+        doc="Open limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "OPEN"],
+    )
+    closed_limit = pvproperty(
+        name=":CLS_DI_RBV",
+        value=0,
+        doc="Closed limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+
+
+class VRCDA(VRC, VRCNO, PVGroup):
+    close_command = pvproperty_with_rbv(
+        name=":CLS_SW",
+        value=0,
+        doc="Epics command to close valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+    close_override = pvproperty_with_rbv(
+        name=":FORCE_CLS",
+        value=0,
+        doc="Epics Command for open the valve in override mode",
+        read_only=False,
+    )
+    override_on = pvproperty_with_rbv(
+        name=":OVRD_ON",
+        value=0,
+        doc="Epics Command to set/reset Override mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    close_ok = pvproperty(
+        name=":CLS_OK_RBV", value=0, doc="used for normally open valves", read_only=True
+    )
+    close_do = pvproperty(
+        name=":CLS_DO_RBV", value=0, doc="PLC Output to close valve", read_only=True
+    )
+    state = pvproperty(
+        name=":STATE_RBV",
+        value=0,
+        doc="Valve state",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=[
+            "Vented",
+            "At Vacuum",
+            "Differential Pressure",
+            "Lost Vacuum",
+            "Ext Fault",
+            "AT Vacuum",
+            "Triggered",
+            "Vacuum Fault",
+            "Close Timeout",
+            "Open Timeout",
+        ],
+    )
+    error_reset = pvproperty_with_rbv(
+        name=":ALM_RST",
+        value=0,
+        doc="Reset Error state to valid by toggling this",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    open_limit = pvproperty(
+        name=":OPN_DI_RBV",
+        value=0,
+        doc="Open limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "OPEN"],
+    )
+    closed_limit = pvproperty(
+        name=":CLS_DI_RBV",
+        value=0,
+        doc="Closed limit switch digital input",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "CLOSE"],
+    )
+    open_command = pvproperty_with_rbv(
+        name=":OPN_SW",
+        value=0,
+        doc="Epics command to Open valve",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["CLOSE", "OPEN"],
+    )
+    interlock_ok = pvproperty(
+        name=":OPN_OK_RBV",
+        value=0,
+        doc="Valve is OK to Open interlock ",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+    )
+    open_do = pvproperty(
+        name=":OPN_DO_RBV",
+        value=0,
+        doc="PLC Output to Open valve, 1 means 24V on command cable",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "TRUE"],
+    )
+    override_status = pvproperty(
+        name=":OVRD_ON_RBV",
+        value=0,
+        doc="Epics Readback on Override mode",
+        read_only=True,
+        dtype=ChannelType.ENUM,
+        enum_strings=["Override OFF", "Override ON"],
+    )
+    override_force_open = pvproperty_with_rbv(
+        name=":FORCE_OPN",
+        value=0,
+        doc="Epics Command to force open the valve inoverride mode",
+        read_only=False,
+        dtype=ChannelType.ENUM,
+        enum_strings=["FALSE", "FORCE OPEN"],
+    )

--- a/simioc/db/valve.py
+++ b/simioc/db/valve.py
@@ -18,7 +18,7 @@ class Stopper(PVGroup):
         read_only=True,
     )
     command = pvproperty(
-        name=":CMD", value=0, doc="Put here to command a stopper move.", read_only=False
+        name=":CMD", value=0, doc="Put here to command a stopper move."
     )
 
 
@@ -29,7 +29,6 @@ class GateValve(Stopper, PVGroup):
         name=":OPN_SW",
         value=0,
         doc="",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -42,8 +41,6 @@ class PPSStopper(PVGroup):
         value=0,
         doc="Stopper state summary PV that tells us if it is in, out, or inconsistent.",
         read_only=True,
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
     )
 
 
@@ -52,30 +49,23 @@ class VCN(PVGroup):
         name=":POS_RDBK_RBV", value=0, doc="valve position readback", read_only=True
     )
     position_control = pvproperty_with_rbv(
-        name=":POS_REQ",
-        value=0,
-        doc="requested positition to control the valve 0-100%",
-        read_only=False,
+        name=":POS_REQ", value=0, doc="requested positition to control the valve 0-100%"
     )
     upper_limit = pvproperty_with_rbv(
-        name=":Limit",
-        value=0,
-        doc="max upper limit position to open the valve 0-100%",
-        read_only=False,
+        name=":Limit", value=0, doc="max upper limit position to open the valve 0-100%"
     )
     interlock_ok = pvproperty(
         name=":ILK_OK_RBV",
         value=0,
         doc="interlock ok status",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["NOT OK", "OK"],
+        read_only=True,
     )
     open_command = pvproperty_with_rbv(
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -83,19 +73,16 @@ class VCN(PVGroup):
         name=":STATE",
         value=0,
         doc="Valve state",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=[
-            "Vented",
-            "At Vacuum",
-            "Differential Pressure",
-            "Lost Vacuum",
-            "Ext Fault",
-            "AT Vacuum",
-            "Triggered",
-            "Vacuum Fault",
-            "Close Timeout",
-            "Open Timeout",
+            "PressInvalid",
+            "GaugeDisconnected",
+            "OoR",
+            "Off",
+            "Starting",
+            "Valid",
+            "ValidHi",
+            "ValidLo",
         ],
     )
     pos_ao = pvproperty(name=":POS_AO_RBV", value=0, doc="", read_only=True)
@@ -106,15 +93,14 @@ class VFS(PVGroup):
         name=":POS_STATE_RBV",
         value=0,
         doc="Ex: OPEN, CLOSED, MOVING, INVALID, OPEN_F",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPEN", "CLOSED", "MOVING", "INVALID", "OPEN_F"],
+        read_only=True,
     )
     vfs_state = pvproperty(
         name=":STATE_RBV",
         value=0,
         doc="Fast Shutter Current State",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=[
             "Vented",
@@ -128,12 +114,12 @@ class VFS(PVGroup):
             "Close Timeout",
             "Open Timeout",
         ],
+        read_only=True,
     )
     request_close = pvproperty_with_rbv(
         name=":CLS_SW",
         value=0,
         doc="Request Fast Shutter to Close. When both closeand open are requested, VFS will close.",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
     )
@@ -141,7 +127,6 @@ class VFS(PVGroup):
         name=":OPN_SW",
         value=0,
         doc="Request Fast Shutter to Open. Requires a risingEPICS signal to open. When both close andopen are requested, VFS will close.",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -149,7 +134,6 @@ class VFS(PVGroup):
         name=":ALM_RST",
         value=0,
         doc="Reset Fast Shutter Vacuum Faults: fastsensor triggered, fast sensor turned off.To open VFS, this needs to be reset to TRUEafter a vacuum event.",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -157,7 +141,6 @@ class VFS(PVGroup):
         name=":OVRD_ON",
         value=0,
         doc="Epics Command to set Override mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
     )
@@ -165,7 +148,6 @@ class VFS(PVGroup):
         name=":FORCE_OPN",
         value=0,
         doc="Epics Command to force openthe valve in override mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "FORCE OPEN"],
     )
@@ -173,53 +155,54 @@ class VFS(PVGroup):
         name=":GFS_RBV",
         value="",
         doc="Gauge Fast Sensor Name",
-        read_only=True,
         max_length=80,
+        read_only=True,
     )
     gfs_trigger = pvproperty(
         name=":TRIG_RBV",
         value=0,
         doc="Gauge Fast Sensor Input Trigger",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["TRIG_OFF", "TRIG_ON"],
+        read_only=True,
     )
     position_close = pvproperty(
         name=":CLS_DI_RBV",
         value=0,
         doc="Fast Shutter Closed Valve Position",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
+        read_only=True,
     )
     position_open = pvproperty(
         name=":OPN_DI_RBV",
         value=0,
         doc="Fast Shutter Open Valve Position",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "OPEN"],
+        read_only=True,
     )
     vac_fault_ok = pvproperty(
         name=":VAC_FAULT_OK_RBV",
         value=0,
         doc="Fast Shutter Vacuum Fault OK Readback",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FAULT", "FAULT OK"],
+        read_only=True,
     )
     mps_ok = pvproperty(
         name=":MPS_FAULT_OK_RBV",
         value=0,
         doc="Fast Shutter Fast Fault Output OK",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["MPS FAULT", "MPS OK"],
+        read_only=True,
     )
     veto_device = pvproperty(
         name=":VETO_DEVICE_RBV",
-        value=0,
+        value="",
         doc="Name of device that can veto this VFS",
+        max_length=80,
         read_only=True,
     )
 
@@ -229,7 +212,6 @@ class ValveBase(PVGroup):
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -237,23 +219,22 @@ class ValveBase(PVGroup):
         name=":OPN_OK_RBV",
         value=0,
         doc="Valve is OK to Open interlock ",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+        read_only=True,
     )
     open_do = pvproperty(
         name=":OPN_DO_RBV",
         value=0,
         doc="PLC Output to Open valve, 1 means 24V on command cable",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -264,7 +245,6 @@ class VVC(ValveBase, PVGroup):
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -272,23 +252,22 @@ class VVC(ValveBase, PVGroup):
         name=":OPN_OK_RBV",
         value=0,
         doc="Valve is OK to Open interlock ",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+        read_only=True,
     )
     open_do = pvproperty(
         name=":OPN_DO_RBV",
         value=0,
         doc="PLC Output to Open valve, 1 means 24V on command cable",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -296,15 +275,14 @@ class VVC(ValveBase, PVGroup):
         name=":OVRD_ON_RBV",
         value=0,
         doc="Epics Readback on Override mode",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
+        read_only=True,
     )
     override_force_open = pvproperty_with_rbv(
         name=":FORCE_OPN",
         value=0,
         doc="Epics Command to force open the valve inoverride mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "FORCE OPEN"],
     )
@@ -315,7 +293,6 @@ class VRC(VVC, PVGroup):
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -323,23 +300,22 @@ class VRC(VVC, PVGroup):
         name=":OPN_OK_RBV",
         value=0,
         doc="Valve is OK to Open interlock ",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+        read_only=True,
     )
     open_do = pvproperty(
         name=":OPN_DO_RBV",
         value=0,
         doc="PLC Output to Open valve, 1 means 24V on command cable",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -347,15 +323,14 @@ class VRC(VVC, PVGroup):
         name=":OVRD_ON_RBV",
         value=0,
         doc="Epics Readback on Override mode",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
+        read_only=True,
     )
     override_force_open = pvproperty_with_rbv(
         name=":FORCE_OPN",
         value=0,
         doc="Epics Command to force open the valve inoverride mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "FORCE OPEN"],
     )
@@ -363,7 +338,6 @@ class VRC(VVC, PVGroup):
         name=":STATE_RBV",
         value=0,
         doc="Valve state",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=[
             "Vented",
@@ -377,22 +351,23 @@ class VRC(VVC, PVGroup):
             "Close Timeout",
             "Open Timeout",
         ],
+        read_only=True,
     )
     open_limit = pvproperty(
         name=":OPN_DI_RBV",
         value=0,
         doc="Open limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "OPEN"],
+        read_only=True,
     )
     closed_limit = pvproperty(
         name=":CLS_DI_RBV",
         value=0,
         doc="Closed limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
+        read_only=True,
     )
 
 
@@ -401,7 +376,6 @@ class VGC(VRC, PVGroup):
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -409,23 +383,22 @@ class VGC(VRC, PVGroup):
         name=":OPN_OK_RBV",
         value=0,
         doc="Valve is OK to Open interlock ",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+        read_only=True,
     )
     open_do = pvproperty(
         name=":OPN_DO_RBV",
         value=0,
         doc="PLC Output to Open valve, 1 means 24V on command cable",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -433,15 +406,14 @@ class VGC(VRC, PVGroup):
         name=":OVRD_ON_RBV",
         value=0,
         doc="Epics Readback on Override mode",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
+        read_only=True,
     )
     override_force_open = pvproperty_with_rbv(
         name=":FORCE_OPN",
         value=0,
         doc="Epics Command to force open the valve inoverride mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "FORCE OPEN"],
     )
@@ -449,7 +421,6 @@ class VGC(VRC, PVGroup):
         name=":STATE_RBV",
         value=0,
         doc="Valve state",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=[
             "Vented",
@@ -463,82 +434,83 @@ class VGC(VRC, PVGroup):
             "Close Timeout",
             "Open Timeout",
         ],
+        read_only=True,
     )
     open_limit = pvproperty(
         name=":OPN_DI_RBV",
         value=0,
         doc="Open limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "OPEN"],
+        read_only=True,
     )
     closed_limit = pvproperty(
         name=":CLS_DI_RBV",
         value=0,
         doc="Closed limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
+        read_only=True,
     )
     diff_press_ok = pvproperty(
         name=":DP_OK_RBV",
         value=0,
         doc="Differential pressure interlock ok",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["DP NOT OK", "DP OK"],
+        read_only=True,
     )
     ext_ilk_ok = pvproperty(
         name=":EXT_ILK_OK_RBV",
         value=0,
         doc="External interlock ok",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["NOT OK", "OK"],
+        read_only=True,
     )
     at_vac_setpoint = pvproperty_with_rbv(
-        name=":AT_VAC_SP", value=0.0, doc="AT VAC Set point value", read_only=False
+        name=":AT_VAC_SP", value=0.0, doc="AT VAC Set point value", precision=2
     )
     setpoint_hysterisis = pvproperty_with_rbv(
-        name=":AT_VAC_HYS", value=0.0, doc="AT VAC Hysteresis", read_only=False
+        name=":AT_VAC_HYS", value=0.0, doc="AT VAC Hysteresis", precision=2
     )
     at_vac = pvproperty(
         name=":AT_VAC_RBV",
         value=0,
         doc="at vacuum setpoint is reached",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["NOT AT VAC", "AT VAC"],
+        read_only=True,
     )
     error = pvproperty(
         name=":ERROR_RBV",
         value=0,
         doc="Error Present",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["NO ERROR", "ERROR PRESENT"],
+        read_only=True,
     )
     mps_state = pvproperty(
         name=":MPS_FAULT_OK_RBV",
         value=0,
         doc="individual valve MPS state for debugging",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["MPS FAULT", "MPS OK"],
+        read_only=True,
     )
     interlock_device_upstream = pvproperty(
         name=":ILK_DEVICE_US_RBV",
         value="",
         doc="Upstream vacuum device used forinterlocking this valve",
-        read_only=True,
         max_length=80,
+        read_only=True,
     )
     interlock_device_downstream = pvproperty(
         name=":ILK_DEVICE_DS_RBV",
         value="",
         doc="Downstream vacuum device used forinterlocking this valve",
-        read_only=True,
         max_length=80,
+        read_only=True,
     )
 
 
@@ -547,7 +519,6 @@ class VGCLegacy(ValveBase, PVGroup):
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -555,23 +526,22 @@ class VGCLegacy(ValveBase, PVGroup):
         name=":OPN_OK_RBV",
         value=0,
         doc="Valve is OK to Open interlock ",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+        read_only=True,
     )
     open_do = pvproperty(
         name=":OPN_DO_RBV",
         value=0,
         doc="PLC Output to Open valve, 1 means 24V on command cable",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -579,17 +549,17 @@ class VGCLegacy(ValveBase, PVGroup):
         name=":OPN_DI_RBV",
         value=0,
         doc="Open limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "OPEN"],
+        read_only=True,
     )
     closed_limit = pvproperty(
         name=":CLS_DI_RBV",
         value=0,
         doc="Closed limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
+        read_only=True,
     )
 
 
@@ -598,7 +568,6 @@ class VGC_2S(VRC, PVGroup):
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -606,23 +575,22 @@ class VGC_2S(VRC, PVGroup):
         name=":OPN_OK_RBV",
         value=0,
         doc="Valve is OK to Open interlock ",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+        read_only=True,
     )
     open_do = pvproperty(
         name=":OPN_DO_RBV",
         value=0,
         doc="PLC Output to Open valve, 1 means 24V on command cable",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -630,15 +598,14 @@ class VGC_2S(VRC, PVGroup):
         name=":OVRD_ON_RBV",
         value=0,
         doc="Epics Readback on Override mode",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
+        read_only=True,
     )
     override_force_open = pvproperty_with_rbv(
         name=":FORCE_OPN",
         value=0,
         doc="Epics Command to force open the valve inoverride mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "FORCE OPEN"],
     )
@@ -646,7 +613,6 @@ class VGC_2S(VRC, PVGroup):
         name=":STATE_RBV",
         value=0,
         doc="Valve state",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=[
             "Vented",
@@ -660,100 +626,99 @@ class VGC_2S(VRC, PVGroup):
             "Close Timeout",
             "Open Timeout",
         ],
+        read_only=True,
     )
     open_limit = pvproperty(
         name=":OPN_DI_RBV",
         value=0,
         doc="Open limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "OPEN"],
+        read_only=True,
     )
     closed_limit = pvproperty(
         name=":CLS_DI_RBV",
         value=0,
         doc="Closed limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
+        read_only=True,
     )
     diff_press_ok = pvproperty(
         name=":DP_OK_RBV",
         value=0,
         doc="Differential pressure interlock ok",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["DP NOT OK", "DP OK"],
+        read_only=True,
     )
     ext_ilk_ok = pvproperty(
         name=":EXT_ILK_OK_RBV",
         value=0,
         doc="External interlock ok",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["NOT OK", "OK"],
+        read_only=True,
     )
     at_vac_setpoint_us = pvproperty_with_rbv(
         name=":AT_VAC_SP",
         value=0.0,
         doc="AT VAC Set point value for the upstream gauge",
-        read_only=False,
+        precision=2,
     )
     setpoint_hysterisis_us = pvproperty_with_rbv(
         name=":AT_VAC_HYS",
         value=0.0,
         doc="AT VAC Hysteresis for the upstream setpoint",
-        read_only=False,
+        precision=2,
     )
     at_vac_setpoint_ds = pvproperty_with_rbv(
         name=":AT_VAC_SP_DS",
         value=0,
         doc="AT VAC Set point value for the downstream gauge",
-        read_only=False,
     )
     setpoint_hysterisis_ds = pvproperty_with_rbv(
         name=":AT_VAC_HYS_DS",
         value=0,
         doc="AT VAC Hysteresis for the downstream setpoint",
-        read_only=False,
     )
     at_vac = pvproperty(
         name=":AT_VAC_RBV",
         value=0,
         doc="at vacuum setpoint is reached",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["NOT AT VAC", "AT VAC"],
+        read_only=True,
     )
     error = pvproperty(
         name=":ERROR_RBV",
         value=0,
         doc="Error Present",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["NO ERROR", "ERROR PRESENT"],
+        read_only=True,
     )
     mps_state = pvproperty(
         name=":MPS_FAULT_OK_RBV",
         value=0,
         doc="individual valve MPS state for debugging",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["MPS FAULT", "MPS OK"],
+        read_only=True,
     )
     interlock_device_upstream = pvproperty(
         name=":ILK_DEVICE_US_RBV",
         value="",
         doc="Upstream vacuum device used forinterlocking this valve",
-        read_only=True,
         max_length=80,
+        read_only=True,
     )
     interlock_device_downstream = pvproperty(
         name=":ILK_DEVICE_DS_RBV",
         value="",
         doc="Downstream vacuum device used forinterlocking this valve",
-        read_only=True,
         max_length=80,
+        read_only=True,
     )
 
 
@@ -762,7 +727,6 @@ class VRCClsLS(VVC, PVGroup):
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -770,23 +734,22 @@ class VRCClsLS(VVC, PVGroup):
         name=":OPN_OK_RBV",
         value=0,
         doc="Valve is OK to Open interlock ",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+        read_only=True,
     )
     open_do = pvproperty(
         name=":OPN_DO_RBV",
         value=0,
         doc="PLC Output to Open valve, 1 means 24V on command cable",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -794,15 +757,14 @@ class VRCClsLS(VVC, PVGroup):
         name=":OVRD_ON_RBV",
         value=0,
         doc="Epics Readback on Override mode",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
+        read_only=True,
     )
     override_force_open = pvproperty_with_rbv(
         name=":FORCE_OPN",
         value=0,
         doc="Epics Command to force open the valve inoverride mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "FORCE OPEN"],
     )
@@ -810,7 +772,6 @@ class VRCClsLS(VVC, PVGroup):
         name=":STATE_RBV",
         value=0,
         doc="Valve state",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=[
             "Vented",
@@ -824,14 +785,15 @@ class VRCClsLS(VVC, PVGroup):
             "Close Timeout",
             "Open Timeout",
         ],
+        read_only=True,
     )
     closed_limit = pvproperty(
         name=":CLS_DI_RBV",
         value=0,
         doc="Closed limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
+        read_only=True,
     )
 
 
@@ -840,7 +802,6 @@ class VVCNO(PVGroup):
         name=":CLS_SW",
         value=0,
         doc="Epics command to close valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
     )
@@ -848,13 +809,11 @@ class VVCNO(PVGroup):
         name=":FORCE_CLS",
         value=0,
         doc="Epics Command for open the valve in override mode",
-        read_only=False,
     )
     override_on = pvproperty_with_rbv(
         name=":OVRD_ON",
         value=0,
         doc="Epics Command to set/reset Override mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
     )
@@ -871,7 +830,6 @@ class VRCNO(VVCNO, PVGroup):
         name=":CLS_SW",
         value=0,
         doc="Epics command to close valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
     )
@@ -879,13 +837,11 @@ class VRCNO(VVCNO, PVGroup):
         name=":FORCE_CLS",
         value=0,
         doc="Epics Command for open the valve in override mode",
-        read_only=False,
     )
     override_on = pvproperty_with_rbv(
         name=":OVRD_ON",
         value=0,
         doc="Epics Command to set/reset Override mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
     )
@@ -899,7 +855,6 @@ class VRCNO(VVCNO, PVGroup):
         name=":STATE_RBV",
         value=0,
         doc="Valve state",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=[
             "Vented",
@@ -913,12 +868,12 @@ class VRCNO(VVCNO, PVGroup):
             "Close Timeout",
             "Open Timeout",
         ],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -926,17 +881,17 @@ class VRCNO(VVCNO, PVGroup):
         name=":OPN_DI_RBV",
         value=0,
         doc="Open limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "OPEN"],
+        read_only=True,
     )
     closed_limit = pvproperty(
         name=":CLS_DI_RBV",
         value=0,
         doc="Closed limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
+        read_only=True,
     )
 
 
@@ -945,7 +900,6 @@ class VRCDA(VRC, VRCNO, PVGroup):
         name=":CLS_SW",
         value=0,
         doc="Epics command to close valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
     )
@@ -953,13 +907,11 @@ class VRCDA(VRC, VRCNO, PVGroup):
         name=":FORCE_CLS",
         value=0,
         doc="Epics Command for open the valve in override mode",
-        read_only=False,
     )
     override_on = pvproperty_with_rbv(
         name=":OVRD_ON",
         value=0,
         doc="Epics Command to set/reset Override mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
     )
@@ -973,7 +925,6 @@ class VRCDA(VRC, VRCNO, PVGroup):
         name=":STATE_RBV",
         value=0,
         doc="Valve state",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=[
             "Vented",
@@ -987,12 +938,12 @@ class VRCDA(VRC, VRCNO, PVGroup):
             "Close Timeout",
             "Open Timeout",
         ],
+        read_only=True,
     )
     error_reset = pvproperty_with_rbv(
         name=":ALM_RST",
         value=0,
         doc="Reset Error state to valid by toggling this",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
     )
@@ -1000,23 +951,22 @@ class VRCDA(VRC, VRCNO, PVGroup):
         name=":OPN_DI_RBV",
         value=0,
         doc="Open limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "OPEN"],
+        read_only=True,
     )
     closed_limit = pvproperty(
         name=":CLS_DI_RBV",
         value=0,
         doc="Closed limit switch digital input",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "CLOSE"],
+        read_only=True,
     )
     open_command = pvproperty_with_rbv(
         name=":OPN_SW",
         value=0,
         doc="Epics command to Open valve",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["CLOSE", "OPEN"],
     )
@@ -1024,31 +974,30 @@ class VRCDA(VRC, VRCNO, PVGroup):
         name=":OPN_OK_RBV",
         value=0,
         doc="Valve is OK to Open interlock ",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
+        read_only=True,
     )
     open_do = pvproperty(
         name=":OPN_DO_RBV",
         value=0,
         doc="PLC Output to Open valve, 1 means 24V on command cable",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "TRUE"],
+        read_only=True,
     )
     override_status = pvproperty(
         name=":OVRD_ON_RBV",
         value=0,
         doc="Epics Readback on Override mode",
-        read_only=True,
         dtype=ChannelType.ENUM,
         enum_strings=["Override OFF", "Override ON"],
+        read_only=True,
     )
     override_force_open = pvproperty_with_rbv(
         name=":FORCE_OPN",
         value=0,
         doc="Epics Command to force open the valve inoverride mode",
-        read_only=False,
         dtype=ChannelType.ENUM,
         enum_strings=["FALSE", "FORCE OPEN"],
     )

--- a/simioc/db/valve.py
+++ b/simioc/db/valve.py
@@ -241,36 +241,6 @@ class ValveBase(PVGroup):
 
 
 class VVC(ValveBase, PVGroup):
-    open_command = pvproperty_with_rbv(
-        name=":OPN_SW",
-        value=0,
-        doc="Epics command to Open valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["CLOSE", "OPEN"],
-    )
-    interlock_ok = pvproperty(
-        name=":OPN_OK_RBV",
-        value=0,
-        doc="Valve is OK to Open interlock ",
-        dtype=ChannelType.ENUM,
-        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
-        read_only=True,
-    )
-    open_do = pvproperty(
-        name=":OPN_DO_RBV",
-        value=0,
-        doc="PLC Output to Open valve, 1 means 24V on command cable",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-        read_only=True,
-    )
-    error_reset = pvproperty_with_rbv(
-        name=":ALM_RST",
-        value=0,
-        doc="Reset Error state to valid by toggling this",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-    )
     override_status = pvproperty(
         name=":OVRD_ON_RBV",
         value=0,
@@ -289,51 +259,6 @@ class VVC(ValveBase, PVGroup):
 
 
 class VRC(VVC, PVGroup):
-    open_command = pvproperty_with_rbv(
-        name=":OPN_SW",
-        value=0,
-        doc="Epics command to Open valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["CLOSE", "OPEN"],
-    )
-    interlock_ok = pvproperty(
-        name=":OPN_OK_RBV",
-        value=0,
-        doc="Valve is OK to Open interlock ",
-        dtype=ChannelType.ENUM,
-        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
-        read_only=True,
-    )
-    open_do = pvproperty(
-        name=":OPN_DO_RBV",
-        value=0,
-        doc="PLC Output to Open valve, 1 means 24V on command cable",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-        read_only=True,
-    )
-    error_reset = pvproperty_with_rbv(
-        name=":ALM_RST",
-        value=0,
-        doc="Reset Error state to valid by toggling this",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-    )
-    override_status = pvproperty(
-        name=":OVRD_ON_RBV",
-        value=0,
-        doc="Epics Readback on Override mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["Override OFF", "Override ON"],
-        read_only=True,
-    )
-    override_force_open = pvproperty_with_rbv(
-        name=":FORCE_OPN",
-        value=0,
-        doc="Epics Command to force open the valve inoverride mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "FORCE OPEN"],
-    )
     state = pvproperty(
         name=":STATE_RBV",
         value=0,
@@ -372,86 +297,6 @@ class VRC(VVC, PVGroup):
 
 
 class VGC(VRC, PVGroup):
-    open_command = pvproperty_with_rbv(
-        name=":OPN_SW",
-        value=0,
-        doc="Epics command to Open valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["CLOSE", "OPEN"],
-    )
-    interlock_ok = pvproperty(
-        name=":OPN_OK_RBV",
-        value=0,
-        doc="Valve is OK to Open interlock ",
-        dtype=ChannelType.ENUM,
-        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
-        read_only=True,
-    )
-    open_do = pvproperty(
-        name=":OPN_DO_RBV",
-        value=0,
-        doc="PLC Output to Open valve, 1 means 24V on command cable",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-        read_only=True,
-    )
-    error_reset = pvproperty_with_rbv(
-        name=":ALM_RST",
-        value=0,
-        doc="Reset Error state to valid by toggling this",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-    )
-    override_status = pvproperty(
-        name=":OVRD_ON_RBV",
-        value=0,
-        doc="Epics Readback on Override mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["Override OFF", "Override ON"],
-        read_only=True,
-    )
-    override_force_open = pvproperty_with_rbv(
-        name=":FORCE_OPN",
-        value=0,
-        doc="Epics Command to force open the valve inoverride mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "FORCE OPEN"],
-    )
-    state = pvproperty(
-        name=":STATE_RBV",
-        value=0,
-        doc="Valve state",
-        dtype=ChannelType.ENUM,
-        enum_strings=[
-            "Vented",
-            "At Vacuum",
-            "Differential Pressure",
-            "Lost Vacuum",
-            "Ext Fault",
-            "AT Vacuum",
-            "Triggered",
-            "Vacuum Fault",
-            "Close Timeout",
-            "Open Timeout",
-        ],
-        read_only=True,
-    )
-    open_limit = pvproperty(
-        name=":OPN_DI_RBV",
-        value=0,
-        doc="Open limit switch digital input",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "OPEN"],
-        read_only=True,
-    )
-    closed_limit = pvproperty(
-        name=":CLS_DI_RBV",
-        value=0,
-        doc="Closed limit switch digital input",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "CLOSE"],
-        read_only=True,
-    )
     diff_press_ok = pvproperty(
         name=":DP_OK_RBV",
         value=0,
@@ -515,36 +360,6 @@ class VGC(VRC, PVGroup):
 
 
 class VGCLegacy(ValveBase, PVGroup):
-    open_command = pvproperty_with_rbv(
-        name=":OPN_SW",
-        value=0,
-        doc="Epics command to Open valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["CLOSE", "OPEN"],
-    )
-    interlock_ok = pvproperty(
-        name=":OPN_OK_RBV",
-        value=0,
-        doc="Valve is OK to Open interlock ",
-        dtype=ChannelType.ENUM,
-        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
-        read_only=True,
-    )
-    open_do = pvproperty(
-        name=":OPN_DO_RBV",
-        value=0,
-        doc="PLC Output to Open valve, 1 means 24V on command cable",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-        read_only=True,
-    )
-    error_reset = pvproperty_with_rbv(
-        name=":ALM_RST",
-        value=0,
-        doc="Reset Error state to valid by toggling this",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-    )
     open_limit = pvproperty(
         name=":OPN_DI_RBV",
         value=0,
@@ -564,86 +379,6 @@ class VGCLegacy(ValveBase, PVGroup):
 
 
 class VGC_2S(VRC, PVGroup):
-    open_command = pvproperty_with_rbv(
-        name=":OPN_SW",
-        value=0,
-        doc="Epics command to Open valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["CLOSE", "OPEN"],
-    )
-    interlock_ok = pvproperty(
-        name=":OPN_OK_RBV",
-        value=0,
-        doc="Valve is OK to Open interlock ",
-        dtype=ChannelType.ENUM,
-        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
-        read_only=True,
-    )
-    open_do = pvproperty(
-        name=":OPN_DO_RBV",
-        value=0,
-        doc="PLC Output to Open valve, 1 means 24V on command cable",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-        read_only=True,
-    )
-    error_reset = pvproperty_with_rbv(
-        name=":ALM_RST",
-        value=0,
-        doc="Reset Error state to valid by toggling this",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-    )
-    override_status = pvproperty(
-        name=":OVRD_ON_RBV",
-        value=0,
-        doc="Epics Readback on Override mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["Override OFF", "Override ON"],
-        read_only=True,
-    )
-    override_force_open = pvproperty_with_rbv(
-        name=":FORCE_OPN",
-        value=0,
-        doc="Epics Command to force open the valve inoverride mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "FORCE OPEN"],
-    )
-    state = pvproperty(
-        name=":STATE_RBV",
-        value=0,
-        doc="Valve state",
-        dtype=ChannelType.ENUM,
-        enum_strings=[
-            "Vented",
-            "At Vacuum",
-            "Differential Pressure",
-            "Lost Vacuum",
-            "Ext Fault",
-            "AT Vacuum",
-            "Triggered",
-            "Vacuum Fault",
-            "Close Timeout",
-            "Open Timeout",
-        ],
-        read_only=True,
-    )
-    open_limit = pvproperty(
-        name=":OPN_DI_RBV",
-        value=0,
-        doc="Open limit switch digital input",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "OPEN"],
-        read_only=True,
-    )
-    closed_limit = pvproperty(
-        name=":CLS_DI_RBV",
-        value=0,
-        doc="Closed limit switch digital input",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "CLOSE"],
-        read_only=True,
-    )
     diff_press_ok = pvproperty(
         name=":DP_OK_RBV",
         value=0,
@@ -723,51 +458,6 @@ class VGC_2S(VRC, PVGroup):
 
 
 class VRCClsLS(VVC, PVGroup):
-    open_command = pvproperty_with_rbv(
-        name=":OPN_SW",
-        value=0,
-        doc="Epics command to Open valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["CLOSE", "OPEN"],
-    )
-    interlock_ok = pvproperty(
-        name=":OPN_OK_RBV",
-        value=0,
-        doc="Valve is OK to Open interlock ",
-        dtype=ChannelType.ENUM,
-        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
-        read_only=True,
-    )
-    open_do = pvproperty(
-        name=":OPN_DO_RBV",
-        value=0,
-        doc="PLC Output to Open valve, 1 means 24V on command cable",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-        read_only=True,
-    )
-    error_reset = pvproperty_with_rbv(
-        name=":ALM_RST",
-        value=0,
-        doc="Reset Error state to valid by toggling this",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-    )
-    override_status = pvproperty(
-        name=":OVRD_ON_RBV",
-        value=0,
-        doc="Epics Readback on Override mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["Override OFF", "Override ON"],
-        read_only=True,
-    )
-    override_force_open = pvproperty_with_rbv(
-        name=":FORCE_OPN",
-        value=0,
-        doc="Epics Command to force open the valve inoverride mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "FORCE OPEN"],
-    )
     state = pvproperty(
         name=":STATE_RBV",
         value=0,
@@ -826,31 +516,6 @@ class VVCNO(PVGroup):
 
 
 class VRCNO(VVCNO, PVGroup):
-    close_command = pvproperty_with_rbv(
-        name=":CLS_SW",
-        value=0,
-        doc="Epics command to close valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "CLOSE"],
-    )
-    close_override = pvproperty_with_rbv(
-        name=":FORCE_CLS",
-        value=0,
-        doc="Epics Command for open the valve in override mode",
-    )
-    override_on = pvproperty_with_rbv(
-        name=":OVRD_ON",
-        value=0,
-        doc="Epics Command to set/reset Override mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["Override OFF", "Override ON"],
-    )
-    close_ok = pvproperty(
-        name=":CLS_OK_RBV", value=0, doc="used for normally open valves", read_only=True
-    )
-    close_do = pvproperty(
-        name=":CLS_DO_RBV", value=0, doc="PLC Output to close valve", read_only=True
-    )
     state = pvproperty(
         name=":STATE_RBV",
         value=0,
@@ -896,108 +561,4 @@ class VRCNO(VVCNO, PVGroup):
 
 
 class VRCDA(VRC, VRCNO, PVGroup):
-    close_command = pvproperty_with_rbv(
-        name=":CLS_SW",
-        value=0,
-        doc="Epics command to close valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "CLOSE"],
-    )
-    close_override = pvproperty_with_rbv(
-        name=":FORCE_CLS",
-        value=0,
-        doc="Epics Command for open the valve in override mode",
-    )
-    override_on = pvproperty_with_rbv(
-        name=":OVRD_ON",
-        value=0,
-        doc="Epics Command to set/reset Override mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["Override OFF", "Override ON"],
-    )
-    close_ok = pvproperty(
-        name=":CLS_OK_RBV", value=0, doc="used for normally open valves", read_only=True
-    )
-    close_do = pvproperty(
-        name=":CLS_DO_RBV", value=0, doc="PLC Output to close valve", read_only=True
-    )
-    state = pvproperty(
-        name=":STATE_RBV",
-        value=0,
-        doc="Valve state",
-        dtype=ChannelType.ENUM,
-        enum_strings=[
-            "Vented",
-            "At Vacuum",
-            "Differential Pressure",
-            "Lost Vacuum",
-            "Ext Fault",
-            "AT Vacuum",
-            "Triggered",
-            "Vacuum Fault",
-            "Close Timeout",
-            "Open Timeout",
-        ],
-        read_only=True,
-    )
-    error_reset = pvproperty_with_rbv(
-        name=":ALM_RST",
-        value=0,
-        doc="Reset Error state to valid by toggling this",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-    )
-    open_limit = pvproperty(
-        name=":OPN_DI_RBV",
-        value=0,
-        doc="Open limit switch digital input",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "OPEN"],
-        read_only=True,
-    )
-    closed_limit = pvproperty(
-        name=":CLS_DI_RBV",
-        value=0,
-        doc="Closed limit switch digital input",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "CLOSE"],
-        read_only=True,
-    )
-    open_command = pvproperty_with_rbv(
-        name=":OPN_SW",
-        value=0,
-        doc="Epics command to Open valve",
-        dtype=ChannelType.ENUM,
-        enum_strings=["CLOSE", "OPEN"],
-    )
-    interlock_ok = pvproperty(
-        name=":OPN_OK_RBV",
-        value=0,
-        doc="Valve is OK to Open interlock ",
-        dtype=ChannelType.ENUM,
-        enum_strings=["OPN ILK NOT OK", "OPN ILK OK"],
-        read_only=True,
-    )
-    open_do = pvproperty(
-        name=":OPN_DO_RBV",
-        value=0,
-        doc="PLC Output to Open valve, 1 means 24V on command cable",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "TRUE"],
-        read_only=True,
-    )
-    override_status = pvproperty(
-        name=":OVRD_ON_RBV",
-        value=0,
-        doc="Epics Readback on Override mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["Override OFF", "Override ON"],
-        read_only=True,
-    )
-    override_force_open = pvproperty_with_rbv(
-        name=":FORCE_OPN",
-        value=0,
-        doc="Epics Command to force open the valve inoverride mode",
-        dtype=ChannelType.ENUM,
-        enum_strings=["FALSE", "FORCE OPEN"],
-    )
+    ...

--- a/simioc/from_ophyd.py
+++ b/simioc/from_ophyd.py
@@ -280,9 +280,10 @@ def convert_from_ophyd(import_name: str, database_name: str):
     print("# Automatically converted from: ")
     print(f"# Module: {import_name}")
     print(f"# Database: {database_name}")
-    print("from caproto import ChannelType")
     print()
+    print("from caproto import ChannelType")
     print("from caproto.server import PVGroup, SubGroup, pvproperty")
+    print()
     print("from .utils import pvproperty_with_rbv")
 
     module = importlib.import_module(import_name)

--- a/simioc/from_ophyd.py
+++ b/simioc/from_ophyd.py
@@ -1,0 +1,265 @@
+"""
+Helper which takes a Python module with ophyd Devices and converts them to
+caproto PVGroups.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import inspect
+import logging
+from typing import Any, List, Optional, Type, cast
+
+import ophyd
+import whatrecord
+from ophyd.signal import EpicsSignalRO
+
+try:
+    from pcdsdevices.signal import PytmcSignalRO, SignalRO
+except ImportError:
+    ro_signal_classes = (EpicsSignalRO,)
+else:
+    ro_signal_classes = (EpicsSignalRO, SignalRO, PytmcSignalRO)
+
+
+logger = logging.getLogger(__name__)
+
+
+DESCRIPTION = __doc__
+
+
+def convert_signal(
+    cpt: ophyd.Component,
+    attr: str,
+    pvname: str,
+    setpoint_pvname: Optional[str],
+    signal: ophyd.signal.EpicsSignalBase,
+    value: Optional[Any] = 0,
+    **kwargs,
+) -> str:
+    cls = "pvproperty"
+    if setpoint_pvname:
+        if f"{setpoint_pvname}_RBV" == pvname:
+            cls = "pvproperty_with_rbv"
+            pvname = setpoint_pvname
+
+    doc = cpt.doc or ""
+    if "Component attribute" in doc:
+        doc = ""
+
+    if isinstance(signal, ro_signal_classes) and cls == "pvproperty":
+        kwargs["read_only"] = True
+
+    if kwargs:
+        kwarg_str = ", " + ", ".join(f"{key}={value}" for key, value in kwargs.items())
+    else:
+        kwarg_str = ""
+    return f"""    {attr} = {cls}(name="{pvname}", value={value}, doc={doc!r}{kwarg_str})"""
+
+
+def find_record_by_suffix(
+    db: whatrecord.db.Database, suffix: str, all_pvnames: List[str]
+) -> Optional[whatrecord.db.RecordInstance]:
+    by_prefix = {}
+    for pv in all_pvnames:
+        for name, instance in db.records.items():
+            if name.endswith(pv):
+                prefix = name[: -len(pv)]
+                by_prefix.setdefault(prefix, {})[pv] = instance
+
+    items = list(by_prefix.items())
+    items.sort(key=lambda kv: len(kv[1]), reverse=True)
+
+    # Pick the most likely one based on other matching PVs
+    for prefix, match_to_instance in items:
+        if suffix in match_to_instance:
+            return match_to_instance[suffix]
+
+
+def info_from_db(db: whatrecord.db.Database, suffix: str, all_pvnames: List[str]):
+    record = find_record_by_suffix(db, suffix, all_pvnames)
+    if not record:
+        return dict(value=0)
+
+    def get_fields(field_names: List[str]):
+        result = []
+        for field in field_names:
+            if field in record.fields:
+                field = cast(whatrecord.db.RecordField, record.fields[field])
+                result.append(field.value)
+            else:
+                result.append("")
+
+        while result and result[-1] == "":
+            result = result[:-1]
+        return result
+
+    # read_only =
+    if record.record_type in ("bi", "bo"):
+        return dict(
+            value=0,
+            dtype="ChannelType.ENUM",
+            enum_strings=list(get_fields(["ZNAM", "ONAM"])),
+        )
+
+    if record.record_type in ("mbbi", "mbbo"):
+        return dict(
+            value=0,
+            dtype="ChannelType.ENUM",
+            enum_strings=get_fields(
+                "ZRST ONST TWST THST FRST FVST SXST SVST EIST NIST TEST ELST TVST TTST FTST FFST".split()
+            ),
+        )
+
+    if record.record_type in ("ai", "ao"):
+        (precision,) = get_fields(["PREC"]) or ["0"]
+        return dict(value=0.0, precision=precision)
+
+    if record.record_type in ("stringin", "stringout"):
+        return dict(value='""', max_length=40)
+
+    if record.record_type in ("waveform",):
+        ftvl, nelm = get_fields(["FTVL", "NELM"])
+        if ftvl == "CHAR":
+            return dict(
+                value='""',
+                max_length=nelm if nelm else 40,
+            )
+        raise
+
+    return dict(value=0)
+
+
+def convert_class(db: whatrecord.db.Database, cls: Type[ophyd.Device]):
+    try:
+        inst = cls(prefix="{{prefix}}", name="")
+    except Exception as ex:
+        logger.warning(f"Can't convert: {cls.__name__}: {ex}")
+        return
+
+    ignored_bases = [
+        "LightpathMixin",
+        "Positioner",
+        "InOutPositioner",
+        "InOutPVStatePositioner",
+    ]
+    bases = list(
+        base.__name__ for base in cls.__bases__ if base.__name__ not in ignored_bases
+    )
+    if "Device" in bases:
+        idx = bases.index("Device")
+        bases[idx] = "PVGroup"
+    else:
+        bases.append("PVGroup")
+
+    base_names = ", ".join(bases)
+    print(f"\n\nclass {cls.__name__}({base_names}):")
+    for dev in inst._sub_devices:
+        print(dev)
+        raise RuntimeError("TODO")
+
+    all_pvnames = [
+        sig.pvname.replace("{{prefix}}", "")
+        for sig in inst._signals.values()
+        if hasattr(sig, "pvname")
+    ]
+
+    non_inherited_components = {
+        attr for attr, cpt in cls.__dict__.items() if isinstance(cpt, ophyd.Component)
+    }
+
+    converted_signals = []
+    for attr, sig in inst._signals.items():
+        if not hasattr(sig, "pvname"):
+            continue
+        if attr not in non_inherited_components:
+            continue
+        pvname = sig.pvname.replace("{{prefix}}", "")
+        setpoint_pvname = getattr(sig, "setpoint_pvname", None)
+        if setpoint_pvname is not None:
+            setpoint_pvname = setpoint_pvname.replace("{{prefix}}", "")
+        cpt = getattr(cls, attr, None)
+        converted_signals.append(
+            convert_signal(
+                cpt,
+                attr,
+                pvname,
+                setpoint_pvname,
+                sig,
+                **info_from_db(db, pvname, all_pvnames),
+            )
+        )
+
+    if not converted_signals:
+        print("    ...")
+    else:
+        print("\n".join(converted_signals))
+
+
+def convert_from_ophyd(import_name: str, database_name: str):
+    print("from caproto import ChannelType")
+
+    print("from caproto.server import PVGroup, SubGroup, pvproperty")
+    print("from .utils import pvproperty_with_rbv")
+
+    module = importlib.import_module(import_name)
+
+    db = cast(
+        whatrecord.Database,
+        whatrecord.parse(database_name),
+    )
+
+    seen = set()
+    to_check = list(
+        obj for attr, obj in inspect.getmembers(module) if inspect.isclass(obj)
+    )
+    classes = []
+
+    while to_check:
+        cls = to_check.pop(0)
+        if cls in seen:
+            continue
+
+        if cls is not ophyd.Device and issubclass(cls, ophyd.Device):
+            seen.add(cls)
+            for base in cls.__bases__:
+                to_check.append(base)
+            classes.append(cls)
+
+    converted = set()
+
+    def recursively_convert(cls):
+        if cls in converted:
+            return
+
+        for base in cls.__bases__:
+            if base in classes:
+                recursively_convert(base)
+
+        if cls in converted:
+            return
+
+        converted.add(cls)
+        convert_class(db, cls)
+
+    for cls in classes:
+        recursively_convert(cls)
+
+
+def create_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.add_argument("import_name", type=str, help="Full import name")
+    parser.add_argument(
+        "database_name", type=str, help="Sample database file with similar components"
+    )
+    return parser
+
+
+def main():
+    parser = create_arg_parser()
+    args = parser.parse_args()
+    convert_from_ophyd(args.import_name, args.database_name)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* `whatrecord` + sample database file-enhanced autoconversion utility
* Converts `pcdsdevices.valves` in its entirety with record information supplying things like enum strings

It may have picked some of the wrong records in certain cases (if all PV suffixes are identical with multiple classes, which isn't unlikely here). This is mostly all I'm willing to do as part of the #12 enhancement for now...